### PR TITLE
add: 添加请求延时管理模块，支持通过.env固定和随机延时配置

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,10 @@
 COOKIES=''
+
+# 请求间隔时间(秒), 2秒以下可能触发风控。建议设置为5秒
+REQUEST_DELAY=5
+
+# 是否启用随机延时 (在基础延时上添加随机波动, true|false)
+ENABLE_RANDOM_DELAY=true
+
+# 随机延时波动范围(秒),实际延时 = REQUEST_DELAY ± RANDOM_DELAY_RANGE
+RANDOM_DELAY_RANGE=1

--- a/apis/xhs_pc_apis.py
+++ b/apis/xhs_pc_apis.py
@@ -4,6 +4,7 @@ import re
 import urllib
 import requests
 from xhs_utils.xhs_util import splice_str, generate_request_params, generate_x_b3_traceid, get_common_headers
+from xhs_utils.request_delay import delay_manager
 from loguru import logger
 
 """
@@ -93,6 +94,7 @@ class XHS_Apis():
                 cursor_score = res_json["data"]["cursor_score"]
                 refresh_type = 3
                 note_index += 20
+                delay_manager.apply_delay()
                 if len(note_list) > require_num:
                     break
         except Exception as e:
@@ -218,6 +220,7 @@ class XHS_Apis():
                 else:
                     break
                 note_list.extend(notes)
+                delay_manager.apply_delay()
                 if len(notes) == 0 or not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -281,6 +284,7 @@ class XHS_Apis():
                 else:
                     break
                 note_list.extend(notes)
+                delay_manager.apply_delay()
                 if len(notes) == 0 or not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -344,6 +348,7 @@ class XHS_Apis():
                 else:
                     break
                 note_list.extend(notes)
+                delay_manager.apply_delay()
                 if len(notes) == 0 or not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -545,6 +550,7 @@ class XHS_Apis():
                 notes = res_json["data"]["items"]
                 note_list.extend(notes)
                 page += 1
+                delay_manager.apply_delay()
                 if len(note_list) >= require_num or not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -604,6 +610,7 @@ class XHS_Apis():
                 users = res_json["data"]["users"]
                 user_list.extend(users)
                 page += 1
+                delay_manager.apply_delay()
                 if len(user_list) >= require_num or not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -661,6 +668,7 @@ class XHS_Apis():
                 else:
                     break
                 note_out_comment_list.extend(comments)
+                delay_manager.apply_delay()
                 if len(note_out_comment_list) == 0 or not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -720,6 +728,7 @@ class XHS_Apis():
                 else:
                     break
                 inner_comment_list.extend(comments)
+                delay_manager.apply_delay()
                 if not res_json["data"]["has_more"]:
                     break
             comment['sub_comments'].extend(inner_comment_list)
@@ -814,6 +823,7 @@ class XHS_Apis():
                 else:
                     break
                 metions_list.extend(metions)
+                delay_manager.apply_delay()
                 if not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -864,6 +874,7 @@ class XHS_Apis():
                 else:
                     break
                 likesAndcollects_list.extend(likesAndcollects)
+                delay_manager.apply_delay()
                 if not res_json["data"]["has_more"]:
                     break
         except Exception as e:
@@ -914,6 +925,7 @@ class XHS_Apis():
                 else:
                     break
                 connections_list.extend(connections)
+                delay_manager.apply_delay()
                 if not res_json["data"]["has_more"]:
                     break
         except Exception as e:

--- a/xhs_utils/request_delay.py
+++ b/xhs_utils/request_delay.py
@@ -1,0 +1,69 @@
+"""
+请求延时管理模块
+提供统一的延时控制机制,支持固定延时和随机波动延时
+
+本模块通过环境变量配置,RequestDelayManager实例化时会执行load_dotenv
+"""
+import time
+import os
+import random
+from loguru import logger
+from dotenv import load_dotenv
+
+
+class RequestDelayManager:
+    """请求延时管理器"""
+
+    def __init__(self):
+        load_dotenv()
+        self.base_delay = float(os.getenv('REQUEST_DELAY', '0'))
+        self.enable_random = os.getenv('ENABLE_RANDOM_DELAY', 'false').lower() == 'true'
+        self.random_range = float(os.getenv('RANDOM_DELAY_RANGE', '0.5'))
+
+    def get_delay(self) -> float:
+        """
+        获取当前的延时时间(秒)
+        如果启用了随机延时,会在基础延时上添加随机波动
+        """
+        if self.base_delay <= 0:
+            return 0
+
+        delay = self.base_delay
+
+        if self.enable_random:
+            # 添加随机波动: ±random_range 范围内的随机值
+            fluctuation = random.uniform(-self.random_range, self.random_range)
+            delay = max(0, delay + fluctuation)  # 确保延时不会为负数
+
+        return delay
+
+    def apply_delay(self):
+        """应用延时"""
+        delay = self.get_delay()
+        if delay > 0:
+            logger.debug(f"请求延时: {delay:.2f}秒")
+            time.sleep(delay)
+
+    def update_config(self, base_delay=None, enable_random=None, random_range=None):
+        """
+        动态更新延时配置
+        :param base_delay: 基础延时(秒)
+        :param enable_random: 是否启用随机延时
+        :param random_range: 随机波动范围(秒)
+        """
+        if base_delay is not None:
+            self.base_delay = float(base_delay)
+            os.environ['REQUEST_DELAY'] = str(base_delay)
+
+        if enable_random is not None:
+            self.enable_random = enable_random
+            os.environ['ENABLE_RANDOM_DELAY'] = str(enable_random).lower()
+
+        if random_range is not None:
+            self.random_range = float(random_range)
+            os.environ['RANDOM_DELAY_RANGE'] = str(random_range)
+
+
+# 全局延时管理器实例
+delay_manager = RequestDelayManager()
+


### PR DESCRIPTION
连续爬取被风控限制，因此增加延时请求模块
`xhs_pc_apis.py`插入了11处`delay_manager.apply_delay()`，有条件可以优化单次请求的复用