### PR TITLE
feat: 新增 Web 可视化采集工具与多平台首页入口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ AGENTS.md
 .agent
 docs
 docx
+
+# Web 工具运行时数据 / 缓存
+data/
+datas/

--- a/comment_gui.py
+++ b/comment_gui.py
@@ -1,0 +1,447 @@
+# -*- coding: utf-8 -*-
+"""
+小红书评论采集可视化界面
+- 输入笔记 URL（多行，每行一个）
+- 实时展示总体进度 / 当前笔记进度 / 已采集评论数 / 日志
+- 完成后可导出为 Excel
+"""
+import os
+import queue
+import threading
+import time
+import tkinter as tk
+import urllib.parse
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+from apis.xhs_pc_apis import XHS_Apis
+from xhs_utils.common_util import load_env
+from xhs_utils.data_util import handle_comment_info, save_to_xlsx
+
+
+STATE_IDLE = "idle"
+STATE_RUNNING = "running"
+STATE_STOPPING = "stopping"
+
+
+def _parse_note_id_token(url: str):
+    parsed = urllib.parse.urlparse(url)
+    note_id = parsed.path.rstrip("/").split("/")[-1]
+    qs = urllib.parse.parse_qs(parsed.query)
+    xsec_token = qs.get("xsec_token", [""])[0]
+    return note_id, xsec_token
+
+
+class CommentFetcher:
+    """对 XHS_Apis 评论接口的薄封装，按页拉取并通过回调上报进度。"""
+
+    def __init__(self, cookies_str: str, proxies: dict = None):
+        self.api = XHS_Apis()
+        self.cookies_str = cookies_str
+        self.proxies = proxies
+        self._stop = threading.Event()
+
+    def stop(self):
+        self._stop.set()
+
+    def stopped(self) -> bool:
+        return self._stop.is_set()
+
+    def fetch_one_note(self, url: str, fetch_sub: bool, progress_cb):
+        """
+        progress_cb(event: str, payload: dict) 事件:
+          - 'note_start' {url, note_id}
+          - 'page' {kind: 'out'|'inner', count, root_id?}
+          - 'note_done' {count}
+          - 'log' {msg}
+          - 'error' {msg}
+        返回扁平化后的评论 dict 列表（已经经过 handle_comment_info）
+        """
+        flat = []
+        try:
+            note_id, xsec_token = _parse_note_id_token(url)
+            progress_cb("note_start", {"url": url, "note_id": note_id})
+
+            # ---- 一级评论分页 ----
+            cursor = ""
+            out_comments = []
+            while not self._stop.is_set():
+                ok, msg, res = self.api.get_note_out_comment(
+                    note_id, cursor, xsec_token, self.cookies_str, self.proxies
+                )
+                if not ok:
+                    progress_cb("error", {"msg": f"一级评论失败: {msg}"})
+                    return flat
+                data = res.get("data", {}) if res else {}
+                page = data.get("comments", []) or []
+                out_comments.extend(page)
+                progress_cb("page", {"kind": "out", "count": len(out_comments)})
+                cursor = str(data.get("cursor", ""))
+                if not data.get("has_more") or not cursor:
+                    break
+
+            if self._stop.is_set():
+                return flat
+
+            # ---- 二级评论分页（可选）----
+            if fetch_sub:
+                for idx, c in enumerate(out_comments, 1):
+                    if self._stop.is_set():
+                        break
+                    if not c.get("sub_comment_has_more"):
+                        continue
+                    sub_cursor = c.get("sub_comment_cursor", "")
+                    while not self._stop.is_set():
+                        ok, msg, res = self.api.get_note_inner_comment(
+                            c, sub_cursor, xsec_token, self.cookies_str, self.proxies
+                        )
+                        if not ok:
+                            progress_cb("error", {"msg": f"二级评论失败: {msg}"})
+                            break
+                        data = res.get("data", {}) if res else {}
+                        sub_page = data.get("comments", []) or []
+                        c.setdefault("sub_comments", []).extend(sub_page)
+                        progress_cb(
+                            "page",
+                            {
+                                "kind": "inner",
+                                "count": idx,
+                                "total": len(out_comments),
+                                "root_id": c.get("id"),
+                            },
+                        )
+                        sub_cursor = str(data.get("cursor", ""))
+                        if not data.get("has_more") or not sub_cursor:
+                            break
+
+            # ---- 扁平化并归一化 ----
+            for c in out_comments:
+                c["note_id"] = note_id
+                c["note_url"] = url
+                try:
+                    flat.append(handle_comment_info(c))
+                except Exception as e:
+                    progress_cb("error", {"msg": f"评论解析失败: {e}"})
+                for sc in c.get("sub_comments", []) or []:
+                    sc["note_id"] = note_id
+                    sc["note_url"] = url
+                    try:
+                        flat.append(handle_comment_info(sc))
+                    except Exception as e:
+                        progress_cb("error", {"msg": f"子评论解析失败: {e}"})
+
+            progress_cb("note_done", {"count": len(flat)})
+        except Exception as e:
+            progress_cb("error", {"msg": f"异常: {e}"})
+        return flat
+
+
+class CommentGUI:
+    POLL_MS = 80
+
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.root.title("小红书评论采集 · 可视化")
+        self.root.geometry("980x720")
+
+        self.event_q: "queue.Queue[tuple]" = queue.Queue()
+        self.state = STATE_IDLE
+        self.worker: threading.Thread = None
+        self.fetcher: CommentFetcher = None
+        self.results: list = []
+        self.start_time = 0.0
+        self.note_total = 0
+        self.note_done = 0
+        self.cur_out = 0
+        self.cur_inner = 0  # 已处理一级评论数（按子评论展开维度）
+        self.cur_inner_total = 0
+
+        self._build_ui()
+        self.root.after(self.POLL_MS, self._poll_events)
+
+    # ---------------- UI ----------------
+    def _build_ui(self):
+        pad = {"padx": 8, "pady": 4}
+
+        # 顶部：Cookie + 选项
+        top = ttk.LabelFrame(self.root, text="配置")
+        top.pack(fill="x", **pad)
+
+        ttk.Label(top, text="Cookie：").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        self.cookie_var = tk.StringVar(value=load_env() or "")
+        self.cookie_entry = ttk.Entry(top, textvariable=self.cookie_var, show="*")
+        self.cookie_entry.grid(row=0, column=1, sticky="ew", padx=6, pady=4)
+        self.show_cookie_var = tk.BooleanVar(value=False)
+        ttk.Checkbutton(
+            top, text="显示", variable=self.show_cookie_var, command=self._toggle_cookie
+        ).grid(row=0, column=2, padx=6)
+        self.fetch_sub_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(top, text="包含二级评论", variable=self.fetch_sub_var).grid(
+            row=0, column=3, padx=6
+        )
+        top.columnconfigure(1, weight=1)
+
+        # 中部：URL 输入
+        mid = ttk.LabelFrame(self.root, text="笔记 URL（每行一个）")
+        mid.pack(fill="both", expand=False, **pad)
+        self.url_text = scrolledtext.ScrolledText(mid, height=6, wrap="none")
+        self.url_text.pack(fill="both", expand=True, padx=6, pady=6)
+
+        # 操作按钮
+        ops = ttk.Frame(self.root)
+        ops.pack(fill="x", **pad)
+        self.start_btn = ttk.Button(ops, text="开始采集", command=self.start)
+        self.start_btn.pack(side="left", padx=4)
+        self.stop_btn = ttk.Button(ops, text="停止", command=self.stop, state="disabled")
+        self.stop_btn.pack(side="left", padx=4)
+        self.save_btn = ttk.Button(
+            ops, text="导出 Excel", command=self.export_excel, state="disabled"
+        )
+        self.save_btn.pack(side="left", padx=4)
+        self.clear_btn = ttk.Button(ops, text="清空日志", command=self._clear_log)
+        self.clear_btn.pack(side="left", padx=4)
+
+        # 进度面板
+        prog = ttk.LabelFrame(self.root, text="进度")
+        prog.pack(fill="x", **pad)
+
+        ttk.Label(prog, text="总体：").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        self.overall_pb = ttk.Progressbar(prog, length=600, mode="determinate")
+        self.overall_pb.grid(row=0, column=1, sticky="ew", padx=6, pady=4)
+        self.overall_lbl = ttk.Label(prog, text="0 / 0")
+        self.overall_lbl.grid(row=0, column=2, sticky="w", padx=6)
+
+        ttk.Label(prog, text="当前笔记：").grid(row=1, column=0, sticky="w", padx=6, pady=4)
+        self.cur_pb = ttk.Progressbar(prog, length=600, mode="indeterminate")
+        self.cur_pb.grid(row=1, column=1, sticky="ew", padx=6, pady=4)
+        self.cur_lbl = ttk.Label(prog, text="—")
+        self.cur_lbl.grid(row=1, column=2, sticky="w", padx=6)
+
+        stats = ttk.Frame(prog)
+        stats.grid(row=2, column=0, columnspan=3, sticky="we", padx=6, pady=4)
+        self.stat_total = ttk.Label(stats, text="已采集评论：0")
+        self.stat_total.pack(side="left", padx=10)
+        self.stat_pages = ttk.Label(stats, text="一级评论页累计：0")
+        self.stat_pages.pack(side="left", padx=10)
+        self.stat_sub = ttk.Label(stats, text="子评论展开：0/0")
+        self.stat_sub.pack(side="left", padx=10)
+        self.stat_time = ttk.Label(stats, text="耗时：0.0s")
+        self.stat_time.pack(side="left", padx=10)
+        prog.columnconfigure(1, weight=1)
+
+        # 日志
+        logf = ttk.LabelFrame(self.root, text="日志")
+        logf.pack(fill="both", expand=True, **pad)
+        self.log = scrolledtext.ScrolledText(logf, height=12, wrap="word", state="disabled")
+        self.log.pack(fill="both", expand=True, padx=6, pady=6)
+
+        # 底部状态
+        self.status = ttk.Label(self.root, text="就绪", anchor="w")
+        self.status.pack(fill="x", padx=8, pady=4)
+
+    def _toggle_cookie(self):
+        self.cookie_entry.config(show="" if self.show_cookie_var.get() else "*")
+
+    def _clear_log(self):
+        self.log.config(state="normal")
+        self.log.delete("1.0", "end")
+        self.log.config(state="disabled")
+
+    def _append_log(self, msg: str):
+        ts = time.strftime("%H:%M:%S")
+        self.log.config(state="normal")
+        self.log.insert("end", f"[{ts}] {msg}\n")
+        self.log.see("end")
+        self.log.config(state="disabled")
+
+    # ---------------- 控制 ----------------
+    def start(self):
+        if self.state != STATE_IDLE:
+            return
+        cookies_str = self.cookie_var.get().strip()
+        if not cookies_str:
+            messagebox.showwarning("缺少 Cookie", "请填入 Cookie 后再开始")
+            return
+        urls = [
+            line.strip()
+            for line in self.url_text.get("1.0", "end").splitlines()
+            if line.strip()
+        ]
+        if not urls:
+            messagebox.showwarning("缺少 URL", "请至少输入一个笔记 URL")
+            return
+
+        self.results = []
+        self.note_total = len(urls)
+        self.note_done = 0
+        self.cur_out = 0
+        self.cur_inner = 0
+        self.cur_inner_total = 0
+        self.start_time = time.time()
+
+        self.overall_pb.config(maximum=self.note_total, value=0)
+        self.overall_lbl.config(text=f"0 / {self.note_total}")
+        self.cur_pb.config(mode="indeterminate")
+        self.cur_pb.start(80)
+        self.cur_lbl.config(text="准备中…")
+        self.stat_total.config(text="已采集评论：0")
+        self.stat_pages.config(text="一级评论页累计：0")
+        self.stat_sub.config(text="子评论展开：0/0")
+        self.stat_time.config(text="耗时：0.0s")
+
+        self.state = STATE_RUNNING
+        self.start_btn.config(state="disabled")
+        self.stop_btn.config(state="normal")
+        self.save_btn.config(state="disabled")
+        self.status.config(text="采集中…")
+
+        self.fetcher = CommentFetcher(cookies_str)
+        self.worker = threading.Thread(
+            target=self._run_worker,
+            args=(urls, self.fetch_sub_var.get()),
+            daemon=True,
+        )
+        self.worker.start()
+
+    def stop(self):
+        if self.state != STATE_RUNNING:
+            return
+        self.state = STATE_STOPPING
+        if self.fetcher:
+            self.fetcher.stop()
+        self.stop_btn.config(state="disabled")
+        self.status.config(text="正在停止…")
+        self._post("log", {"msg": "用户请求停止，等待当前请求结束…"})
+
+    def export_excel(self):
+        if not self.results:
+            messagebox.showinfo("无数据", "没有可导出的评论")
+            return
+        default = f"comments_{time.strftime('%Y%m%d_%H%M%S')}.xlsx"
+        path = filedialog.asksaveasfilename(
+            defaultextension=".xlsx",
+            initialfile=default,
+            filetypes=[("Excel", "*.xlsx")],
+        )
+        if not path:
+            return
+        try:
+            save_to_xlsx(self.results, path, type="comment")
+            self._append_log(f"已导出 {len(self.results)} 条评论 → {path}")
+            messagebox.showinfo("导出成功", f"共 {len(self.results)} 条评论\n{path}")
+        except Exception as e:
+            messagebox.showerror("导出失败", str(e))
+
+    # ---------------- 工作线程 ----------------
+    def _run_worker(self, urls, fetch_sub):
+        try:
+            for i, url in enumerate(urls, 1):
+                if self.fetcher.stopped():
+                    break
+                self._post("note_index", {"i": i, "total": len(urls), "url": url})
+                comments = self.fetcher.fetch_one_note(url, fetch_sub, self._post)
+                self._post("note_collected", {"items": comments})
+        finally:
+            self._post("done", {})
+
+    def _post(self, event: str, payload: dict):
+        self.event_q.put((event, payload))
+
+    # ---------------- 事件循环 ----------------
+    def _poll_events(self):
+        try:
+            while True:
+                event, payload = self.event_q.get_nowait()
+                self._handle_event(event, payload)
+        except queue.Empty:
+            pass
+
+        if self.state == STATE_RUNNING:
+            elapsed = time.time() - self.start_time
+            self.stat_time.config(text=f"耗时：{elapsed:.1f}s")
+
+        self.root.after(self.POLL_MS, self._poll_events)
+
+    def _handle_event(self, event: str, payload: dict):
+        if event == "note_index":
+            self.cur_out = 0
+            self.cur_inner = 0
+            self.cur_inner_total = 0
+            self.cur_pb.config(mode="indeterminate")
+            self.cur_pb.start(80)
+            short = payload["url"]
+            if len(short) > 70:
+                short = short[:67] + "..."
+            self.cur_lbl.config(text=f"[{payload['i']}/{payload['total']}] {short}")
+            self._append_log(f"开始第 {payload['i']}/{payload['total']} 条：{payload['url']}")
+
+        elif event == "note_start":
+            self._append_log(f"  note_id={payload['note_id']}")
+
+        elif event == "page":
+            if payload["kind"] == "out":
+                self.cur_out = payload["count"]
+                self.stat_pages.config(text=f"一级评论页累计：{self.cur_out}")
+            else:
+                self.cur_inner = payload["count"]
+                self.cur_inner_total = payload.get("total", self.cur_inner_total)
+                # 切换为确定模式展示子评论扫描进度
+                if self.cur_inner_total:
+                    self.cur_pb.stop()
+                    self.cur_pb.config(
+                        mode="determinate",
+                        maximum=self.cur_inner_total,
+                        value=self.cur_inner,
+                    )
+                self.stat_sub.config(
+                    text=f"子评论展开：{self.cur_inner}/{self.cur_inner_total}"
+                )
+
+        elif event == "note_done":
+            self._append_log(f"  ✓ 完成，共 {payload['count']} 条")
+
+        elif event == "note_collected":
+            self.note_done += 1
+            self.results.extend(payload.get("items", []))
+            self.overall_pb.config(value=self.note_done)
+            self.overall_lbl.config(text=f"{self.note_done} / {self.note_total}")
+            self.stat_total.config(text=f"已采集评论：{len(self.results)}")
+            self.cur_pb.stop()
+            self.cur_pb.config(mode="determinate", maximum=1, value=1)
+
+        elif event == "error":
+            self._append_log(f"  ✗ {payload['msg']}")
+
+        elif event == "log":
+            self._append_log(payload["msg"])
+
+        elif event == "done":
+            self.cur_pb.stop()
+            self.cur_pb.config(mode="determinate", value=0)
+            elapsed = time.time() - self.start_time
+            self.stat_time.config(text=f"耗时：{elapsed:.1f}s")
+            self.state = STATE_IDLE
+            self.start_btn.config(state="normal")
+            self.stop_btn.config(state="disabled")
+            self.save_btn.config(state="normal" if self.results else "disabled")
+            self.status.config(
+                text=f"完成：{self.note_done}/{self.note_total} 条笔记，{len(self.results)} 条评论"
+            )
+            self._append_log(
+                f"全部完成，共 {len(self.results)} 条评论，用时 {elapsed:.1f}s"
+            )
+
+
+def main():
+    root = tk.Tk()
+    try:
+        style = ttk.Style()
+        if "vista" in style.theme_names():
+            style.theme_use("vista")
+    except Exception:
+        pass
+    CommentGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ aiohttp
 opencv-python
 numpy
 qrcode
+flask

--- a/server.py
+++ b/server.py
@@ -1,0 +1,935 @@
+# -*- coding: utf-8 -*-
+"""
+小红书采集工具 — Web 后端
+- 三种采集类型（comments / homepage / search）
+- 每个任务可被多次「追加运行」，持久化到 data/tasks/<id>/
+- SSE 实时上报当前 run 的事件流
+"""
+import json
+import os
+import shutil
+import tempfile
+import threading
+import time
+import urllib.parse
+import uuid
+from typing import Any, Dict, List, Optional
+
+import requests
+from flask import Flask, Response, jsonify, render_template, request, send_file
+
+from apis.xhs_pc_apis import XHS_Apis
+from xhs_utils.common_util import load_env
+from xhs_utils.data_util import handle_comment_info, handle_note_info, save_to_xlsx
+
+
+app = Flask(
+    __name__,
+    template_folder="web/templates",
+    static_folder="web/static",
+    static_url_path="/assets",
+)
+app.config["JSON_AS_ASCII"] = False
+
+XHS = XHS_Apis()
+TASKS: Dict[str, "Task"] = {}
+TASKS_LOCK = threading.Lock()
+
+STORAGE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "tasks"))
+os.makedirs(STORAGE_DIR, exist_ok=True)
+
+
+# ───────────────────────────── helpers ─────────────────────────────
+
+
+def _parse_note_id_token(url: str):
+    parsed = urllib.parse.urlparse(url)
+    note_id = parsed.path.rstrip("/").split("/")[-1]
+    qs = urllib.parse.parse_qs(parsed.query)
+    return note_id, qs.get("xsec_token", [""])[0]
+
+
+def _flatten_note_card(item: dict, fallback_url: str = "") -> dict:
+    note_id = item.get("id") or item.get("note_id") or ""
+    xsec = item.get("xsec_token", "")
+    url = (
+        fallback_url
+        or (
+            f"https://www.xiaohongshu.com/explore/{note_id}"
+            + (f"?xsec_token={xsec}" if xsec else "")
+        )
+    )
+    card = item.get("note_card") or {}
+    user = card.get("user") or {}
+    interact = card.get("interact_info") or {}
+    cover = ""
+    images = card.get("image_list") or []
+    if images:
+        try:
+            cover = (
+                images[0].get("info_list", [{}])[1].get("url")
+                or images[0].get("url_default")
+                or images[0].get("url")
+                or ""
+            )
+        except Exception:
+            cover = images[0].get("url_default", "") or images[0].get("url", "")
+    raw_type = card.get("type", "")
+    type_cn = "图集" if raw_type == "normal" else ("视频" if raw_type == "video" else raw_type)
+    user_id = user.get("user_id", "")
+    return {
+        "note_id": note_id,
+        "note_url": url,
+        "xsec_token": xsec,
+        "note_type": type_cn,
+        "title": card.get("display_title") or card.get("title") or "",
+        "desc": "",
+        "user_id": user_id,
+        "home_url": (f"https://www.xiaohongshu.com/user/profile/{user_id}" if user_id else ""),
+        "nickname": user.get("nickname") or user.get("nick_name") or "",
+        "avatar": user.get("avatar", ""),
+        "liked_count": interact.get("liked_count", ""),
+        "collected_count": interact.get("collected_count", ""),
+        "comment_count": interact.get("comment_count", ""),
+        "share_count": interact.get("share_count", ""),
+        "video_cover": "",
+        "video_addr": "",
+        "image_list": [cover] if cover else [],
+        "tags": [],
+        "upload_time": "",
+        "ip_location": "",
+        "cover": cover,
+        "_detailed": False,
+    }
+
+
+def _strip_cookies(params: dict) -> dict:
+    return {k: v for k, v in (params or {}).items() if k != "cookies"}
+
+
+def _atomic_write(path: str, content: str):
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp, path)
+
+
+# ───────────────────────────── task model ─────────────────────────────
+
+
+class Task:
+    def __init__(self, kind: str, params: dict, name: Optional[str] = None, tid: Optional[str] = None):
+        self.id = tid or uuid.uuid4().hex[:10]
+        self.kind = kind  # 首次运行的类型，仅作展示参考
+        self.name = name or self._default_name(kind, params)
+        self.params: Dict[str, Any] = dict(params or {})
+        self.notes: List[dict] = []
+        self.comments: List[dict] = []
+        self.runs: List[dict] = []  # {kind, params, started, finished, state, added_notes, added_comments}
+        self.created = time.time()
+        self.updated = self.created
+
+        # 实时态（不持久化）
+        self.events: List[dict] = []
+        self.cond = threading.Condition()
+        self.state = "idle"  # idle | running | stopped
+        self.run_lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self._cur_run: Optional[dict] = None
+        self._cur_run_idx: int = 0  # events 在本次 run 起始的位置
+
+        self.dir = os.path.join(STORAGE_DIR, self.id)
+
+    @staticmethod
+    def _default_name(kind: str, params: dict) -> str:
+        if kind == "search":
+            return f"搜索 · {params.get('query','')}"
+        if kind == "homepage":
+            url = params.get("user_url", "")
+            uid = url.rstrip("/").split("/")[-1].split("?")[0][:10]
+            return f"主页 · {uid}"
+        if kind == "comments":
+            urls = params.get("urls") or []
+            return f"评论 · {len(urls)} 条"
+        return kind
+
+    # ── persistence ───────────────────────
+    def _ensure_dir(self):
+        os.makedirs(self.dir, exist_ok=True)
+
+    def persist_meta(self):
+        self._ensure_dir()
+        meta = {
+            "id": self.id,
+            "kind": self.kind,
+            "name": self.name,
+            "params": _strip_cookies(self.params),
+            "created": self.created,
+            "updated": self.updated,
+            "runs": [
+                {**r, "params": _strip_cookies(r.get("params") or {})} for r in self.runs
+            ],
+            "counts": {"notes": len(self.notes), "comments": len(self.comments)},
+        }
+        _atomic_write(os.path.join(self.dir, "meta.json"), json.dumps(meta, ensure_ascii=False, indent=2))
+
+    def rewrite_notes(self):
+        self._ensure_dir()
+        path = os.path.join(self.dir, "notes.jsonl")
+        with open(path + ".tmp", "w", encoding="utf-8") as f:
+            for n in self.notes:
+                f.write(json.dumps(n, ensure_ascii=False) + "\n")
+        os.replace(path + ".tmp", path)
+
+    def append_comments(self, items: List[dict]):
+        if not items:
+            return
+        self._ensure_dir()
+        with open(os.path.join(self.dir, "comments.jsonl"), "a", encoding="utf-8") as f:
+            for c in items:
+                f.write(json.dumps(c, ensure_ascii=False) + "\n")
+
+    @classmethod
+    def load(cls, tid: str) -> Optional["Task"]:
+        d = os.path.join(STORAGE_DIR, tid)
+        meta_path = os.path.join(d, "meta.json")
+        if not os.path.exists(meta_path):
+            return None
+        try:
+            meta = json.loads(open(meta_path, "r", encoding="utf-8").read())
+        except Exception:
+            return None
+        t = cls(meta.get("kind", "comments"), meta.get("params") or {}, name=meta.get("name"), tid=meta["id"])
+        t.created = meta.get("created", t.created)
+        t.updated = meta.get("updated", t.updated)
+        t.runs = meta.get("runs", []) or []
+        # notes
+        notes_path = os.path.join(d, "notes.jsonl")
+        if os.path.exists(notes_path):
+            with open(notes_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        t.notes.append(json.loads(line))
+                    except Exception:
+                        pass
+        # comments
+        cms_path = os.path.join(d, "comments.jsonl")
+        if os.path.exists(cms_path):
+            with open(cms_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        t.comments.append(json.loads(line))
+                    except Exception:
+                        pass
+        return t
+
+    def delete_storage(self):
+        try:
+            shutil.rmtree(self.dir, ignore_errors=True)
+        except Exception:
+            pass
+
+    # ── runtime ───────────────────────────
+    def emit(self, t: str, p: Optional[dict] = None):
+        evt = {"t": t, "p": p or {}, "ts": time.time(), "i": len(self.events)}
+        with self.cond:
+            self.events.append(evt)
+            self.cond.notify_all()
+
+    def stop(self):
+        if self.state == "running":
+            self.stop_event.set()
+            self.emit("log", {"msg": "停止指令已发出"})
+
+    def stopped(self) -> bool:
+        return self.stop_event.is_set()
+
+    def begin_run(self, kind: str, params: dict):
+        with self.run_lock:
+            if self.state == "running":
+                raise RuntimeError("task is already running")
+            self.state = "running"
+            self.stop_event.clear()
+            self.params = dict(params or {})
+            self._cur_run = {
+                "kind": kind,
+                "params": _strip_cookies(params),
+                "started": time.time(),
+                "finished": None,
+                "state": "running",
+                "added_notes_start": len(self.notes),
+                "added_comments_start": len(self.comments),
+            }
+            self._cur_run_idx = len(self.events)
+            self.runs.append(self._cur_run)
+            self.persist_meta()
+
+    def end_run(self):
+        run = self._cur_run
+        if run is None:
+            return
+        run["finished"] = time.time()
+        run["added_notes"] = len(self.notes) - run.pop("added_notes_start", len(self.notes))
+        run["added_comments"] = len(self.comments) - run.pop("added_comments_start", len(self.comments))
+        run["state"] = "stopped" if self.stopped() else "done"
+        # 状态切换 + 通知必须在 cond 内，否则 SSE 生成器可能在 done 事件 emit 之前看到 idle 而提前关闭流
+        with self.cond:
+            self.state = "idle"
+            self.updated = time.time()
+            self.cond.notify_all()
+        self.persist_meta()
+        self._cur_run = None
+
+    def to_summary(self) -> dict:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "name": self.name,
+            "state": self.state,
+            "params": _strip_cookies(self.params),
+            "notes": len(self.notes),
+            "comments": len(self.comments),
+            "created": self.created,
+            "updated": self.updated,
+            "runs": [{**r, "params": _strip_cookies(r.get("params") or {})} for r in self.runs],
+        }
+
+
+# ───────────────────────────── enrichment / runners ─────────────────────────────
+
+
+def _enrich_note_details(task: Task):
+    cookies_str = task.params["cookies"]
+    notes = task.notes
+    target_ids = task.params.get("note_ids")
+    if target_ids:
+        target_set = set(target_ids)
+        pending = [i for i, n in enumerate(notes)
+                   if not n.get("_detailed") and n.get("note_id") in target_set]
+    else:
+        pending = [i for i, n in enumerate(notes) if not n.get("_detailed")]
+    if not pending:
+        return
+    task.emit("phase", {"name": "details", "total": len(pending)})
+    for k, idx in enumerate(pending, 1):
+        if task.stopped():
+            break
+        n = notes[idx]
+        url = n.get("note_url") or ""
+        if not url:
+            continue
+        task.emit("note_index", {"i": k, "total": len(pending), "url": url})
+        try:
+            ok, msg, res = XHS.get_note_info(url, cookies_str)
+            if not ok:
+                task.emit("error", {"msg": f"详情失败: {msg}"})
+                continue
+            note_item = res["data"]["items"][0]
+            note_item["url"] = url
+            full = handle_note_info(note_item)
+            full["xsec_token"] = n.get("xsec_token", "")
+            full["cover"] = (
+                full.get("video_cover")
+                or (full.get("image_list") or [None])[0]
+                or n.get("cover", "")
+            )
+            full["_detailed"] = True
+            notes[idx] = full
+            task.emit("note_done", {"count": idx + 1, "kind": "detail"})
+        except Exception as e:
+            task.emit("error", {"msg": f"详情异常: {e}"})
+    task.rewrite_notes()
+    task.emit("notes_collected", {"count": len(notes)})
+
+
+def _fetch_comments_for_url(task: Task, url: str, fetch_sub: bool, cookies_str: str):
+    note_id, xsec_token = _parse_note_id_token(url)
+    task.emit("note_start", {"url": url, "note_id": note_id})
+
+    cursor = ""
+    out_comments: List[dict] = []
+    while not task.stopped():
+        ok, msg, res = XHS.get_note_out_comment(note_id, cursor, xsec_token, cookies_str)
+        if not ok:
+            task.emit("error", {"msg": f"一级评论失败: {msg}"})
+            return []
+        data = (res or {}).get("data", {}) or {}
+        page = data.get("comments", []) or []
+        out_comments.extend(page)
+        task.emit("page", {"kind": "out", "count": len(out_comments)})
+        cursor = str(data.get("cursor", ""))
+        if not data.get("has_more") or not cursor:
+            break
+    if task.stopped():
+        return []
+
+    if fetch_sub:
+        for idx, c in enumerate(out_comments, 1):
+            if task.stopped():
+                break
+            if not c.get("sub_comment_has_more"):
+                continue
+            sub_cursor = c.get("sub_comment_cursor", "")
+            while not task.stopped():
+                ok, msg, res = XHS.get_note_inner_comment(c, sub_cursor, xsec_token, cookies_str)
+                if not ok:
+                    task.emit("error", {"msg": f"二级评论失败: {msg}"})
+                    break
+                data = (res or {}).get("data", {}) or {}
+                sub_page = data.get("comments", []) or []
+                c.setdefault("sub_comments", []).extend(sub_page)
+                task.emit(
+                    "page",
+                    {"kind": "inner", "count": idx, "total": len(out_comments), "root_id": c.get("id")},
+                )
+                sub_cursor = str(data.get("cursor", ""))
+                if not data.get("has_more") or not sub_cursor:
+                    break
+
+    flat: List[dict] = []
+    for c in out_comments:
+        c["note_id"] = note_id
+        c["note_url"] = url
+        root_id = c.get("id", "")
+        try:
+            flat.append(handle_comment_info(c, parent_comment_id="", level=1))
+        except Exception as e:
+            task.emit("error", {"msg": f"评论解析失败: {e}"})
+        for sc in c.get("sub_comments", []) or []:
+            sc["note_id"] = note_id
+            sc["note_url"] = url
+            try:
+                flat.append(handle_comment_info(sc, parent_comment_id=root_id, level=2))
+            except Exception as e:
+                task.emit("error", {"msg": f"子评论解析失败: {e}"})
+
+    task.emit("note_done", {"count": len(flat)})
+    return flat
+
+
+def run_comments_task(task: Task):
+    p = task.params
+    cookies_str = p["cookies"]
+    urls: List[str] = p["urls"]
+    fetch_sub: bool = p.get("fetch_sub", True)
+
+    task.emit("phase", {"name": "comments", "total": len(urls)})
+    for i, url in enumerate(urls, 1):
+        if task.stopped():
+            break
+        task.emit("note_index", {"i": i, "total": len(urls), "url": url})
+        comments = _fetch_comments_for_url(task, url, fetch_sub, cookies_str)
+        task.comments.extend(comments)
+        task.append_comments(comments)
+        task.emit("comments_progress", {"total": len(task.comments)})
+
+
+def _enqueue_comments_followup(task: Task, urls: List[str]):
+    p = task.params
+    if not p.get("with_comments"):
+        return
+    fetch_sub = p.get("fetch_sub", True)
+    task.emit("phase", {"name": "comments", "total": len(urls)})
+    for i, url in enumerate(urls, 1):
+        if task.stopped():
+            break
+        task.emit("note_index", {"i": i, "total": len(urls), "url": url})
+        comments = _fetch_comments_for_url(task, url, fetch_sub, p["cookies"])
+        task.comments.extend(comments)
+        task.append_comments(comments)
+        task.emit("comments_progress", {"total": len(task.comments)})
+
+
+def run_homepage_task(task: Task):
+    p = task.params
+    cookies_str = p["cookies"]
+    user_url: str = p["user_url"]
+
+    task.emit("phase", {"name": "homepage"})
+    task.emit("log", {"msg": f"拉取主页 {user_url}"})
+
+    parsed = urllib.parse.urlparse(user_url)
+    user_id = parsed.path.rstrip("/").split("/")[-1]
+    qs = urllib.parse.parse_qs(parsed.query)
+    xsec_token = qs.get("xsec_token", [""])[0]
+    xsec_source = qs.get("xsec_source", ["pc_search"])[0]
+
+    cursor = ""
+    raw_notes: List[dict] = []
+    while not task.stopped():
+        ok, msg, res = XHS.get_user_note_info(user_id, cursor, cookies_str, xsec_token, xsec_source)
+        if not ok:
+            task.emit("error", {"msg": f"主页拉取失败: {msg}"})
+            return
+        data = (res or {}).get("data", {}) or {}
+        page = data.get("notes", []) or []
+        raw_notes.extend(page)
+        task.emit("page", {"kind": "user_posts", "count": len(raw_notes)})
+        cursor = str(data.get("cursor", ""))
+        if not page or not data.get("has_more") or not cursor:
+            break
+
+    note_urls: List[str] = []
+    existing_ids = {n.get("note_id") for n in task.notes}
+    for it in raw_notes:
+        nid = it.get("note_id") or it.get("id")
+        if nid in existing_ids:
+            continue
+        xt = it.get("xsec_token", "")
+        url = (
+            f"https://www.xiaohongshu.com/explore/{nid}"
+            + (f"?xsec_token={xt}" if xt else "")
+        )
+        flat = _flatten_note_card({"id": nid, "xsec_token": xt, "note_card": it}, fallback_url=url)
+        task.notes.append(flat)
+        note_urls.append(url)
+    task.rewrite_notes()
+    task.emit("notes_collected", {"count": len(task.notes)})
+
+    if p.get("fetch_detail"):
+        _enrich_note_details(task)
+    _enqueue_comments_followup(task, note_urls)
+
+
+def run_search_task(task: Task):
+    p = task.params
+    cookies_str = p["cookies"]
+    query: str = p["query"]
+    require_num: int = int(p.get("require_num", 20))
+    sort_type_choice = int(p.get("sort_type", 0))
+    note_type = int(p.get("note_type", 0))
+    note_time = int(p.get("note_time", 0))
+
+    task.emit("phase", {"name": "search", "target": require_num})
+    task.emit("log", {"msg": f"关键词「{query}」目标 {require_num} 条"})
+
+    from xhs_utils.xhs_util import generate_search_id
+
+    page = 1
+    raw_notes: List[dict] = []
+    root_search_id = generate_search_id()
+    while not task.stopped():
+        search_id = generate_search_id(root_search_id)
+        ok, msg, res = XHS.search_note(
+            query, cookies_str, page, sort_type_choice, note_type, note_time, 0, 0, "", search_id
+        )
+        if not ok:
+            task.emit("error", {"msg": f"搜索失败: {msg}"})
+            return
+        data = (res or {}).get("data", {}) or {}
+        items = data.get("items", []) or []
+        items = [x for x in items if x.get("model_type") == "note"]
+        raw_notes.extend(items)
+        task.emit("page", {"kind": "search", "count": len(raw_notes), "total": require_num, "page": page})
+        page += 1
+        if len(raw_notes) >= require_num or not data.get("has_more"):
+            break
+
+    if len(raw_notes) > require_num:
+        raw_notes = raw_notes[:require_num]
+
+    note_urls: List[str] = []
+    existing_ids = {n.get("note_id") for n in task.notes}
+    for item in raw_notes:
+        flat = _flatten_note_card(item)
+        if flat["note_id"] in existing_ids:
+            continue
+        task.notes.append(flat)
+        note_urls.append(flat["note_url"])
+    task.rewrite_notes()
+    task.emit("notes_collected", {"count": len(task.notes)})
+
+    if p.get("fetch_detail"):
+        _enrich_note_details(task)
+    _enqueue_comments_followup(task, note_urls)
+
+
+def run_task_thread(task: Task, kind: str):
+    task.emit("task_start", {"kind": kind, "tid": task.id, "name": task.name})
+    try:
+        if kind == "comments":
+            run_comments_task(task)
+        elif kind == "homepage":
+            run_homepage_task(task)
+        elif kind == "search":
+            run_search_task(task)
+        elif kind == "details":
+            # 补全笔记详情：扫描 task.notes 中 _detailed=False 的项
+            if not task.notes:
+                task.emit("error", {"msg": "当前任务没有笔记，无法补全详情"})
+            else:
+                _enrich_note_details(task)
+        else:
+            task.emit("error", {"msg": f"未知任务类型 {kind}"})
+    except Exception as e:
+        task.emit("error", {"msg": f"任务异常: {e}"})
+    finally:
+        cur = task._cur_run or {}
+        started = cur.get("started") or time.time()
+        notes_start = cur.get("added_notes_start", len(task.notes))
+        comments_start = cur.get("added_comments_start", len(task.comments))
+        final_state = "stopped" if task.stopped() else "done"
+        # done 必须先发，再 end_run 切 state，否则 SSE 流可能错过 done 事件
+        task.emit(
+            "done",
+            {
+                "state": final_state,
+                "notes": len(task.notes),
+                "comments": len(task.comments),
+                "added_notes": len(task.notes) - notes_start,
+                "added_comments": len(task.comments) - comments_start,
+                "elapsed": time.time() - started,
+            },
+        )
+        task.end_run()
+
+
+# ───────────────────────────── routes ─────────────────────────────
+
+
+def _build_run_params(kind: str, body: dict) -> Dict[str, Any]:
+    cookies_str = (body.get("cookies") or load_env() or "").strip()
+    if not cookies_str:
+        raise ValueError("missing cookies")
+    params: Dict[str, Any] = {"cookies": cookies_str}
+    if kind == "details":
+        # 可选 note_ids：限定要补抓的笔记；为空时补全所有 _detailed=False 的笔记
+        ids = body.get("note_ids")
+        if isinstance(ids, list) and ids:
+            params["note_ids"] = [str(x) for x in ids]
+        return params
+    if kind == "comments":
+        urls = [u.strip() for u in (body.get("urls") or []) if u and u.strip()]
+        if not urls:
+            raise ValueError("no urls")
+        params["urls"] = urls
+        params["fetch_sub"] = bool(body.get("fetch_sub", True))
+    elif kind == "homepage":
+        user_url = (body.get("user_url") or "").strip()
+        if not user_url:
+            raise ValueError("missing user_url")
+        params["user_url"] = user_url
+        params["fetch_detail"] = bool(body.get("fetch_detail", True))
+        params["with_comments"] = bool(body.get("with_comments", False))
+        params["fetch_sub"] = bool(body.get("fetch_sub", True))
+    elif kind == "search":
+        query = (body.get("query") or "").strip()
+        if not query:
+            raise ValueError("missing query")
+        params["query"] = query
+        params["require_num"] = int(body.get("require_num", 20))
+        params["sort_type"] = int(body.get("sort_type", 0))
+        params["note_type"] = int(body.get("note_type", 0))
+        params["note_time"] = int(body.get("note_time", 0))
+        params["fetch_detail"] = bool(body.get("fetch_detail", True))
+        params["with_comments"] = bool(body.get("with_comments", False))
+        params["fetch_sub"] = bool(body.get("fetch_sub", True))
+    else:
+        raise ValueError("invalid kind")
+    return params
+
+
+# 工具集首页 — 添加新工具只需在这里追加一项
+TOOLS = [
+    {
+        "id": "xhs",
+        "name": "小红书采集工具",
+        "desc": "笔记 / 评论批量采集，支持历史任务追加、详情补全、多任务管理",
+        "icon": "📕",
+        "color": "#E13A2C",
+        "color_soft": "#FEE2DD",
+        "url": "/xhs",
+    },
+    # 添加更多工具：
+    # { "id": "douyin", "name": "抖音采集", "desc": "...", "icon": "🎵",
+    #   "color": "#000000", "color_soft": "#F5F5F5", "url": "/douyin" },
+]
+
+
+@app.route("/")
+def home():
+    return render_template("home.html", tools=TOOLS)
+
+
+@app.route("/xhs")
+def xhs_index():
+    return render_template("index.html")
+
+
+@app.route("/api/cookie")
+def api_cookie():
+    cookie = load_env() or ""
+    return jsonify(
+        {
+            "has_cookie": bool(cookie),
+            "preview": (cookie[:10] + "…" + cookie[-6:]) if cookie else "",
+            "length": len(cookie),
+        }
+    )
+
+
+@app.route("/api/run", methods=["POST"])
+def api_run():
+    body = request.get_json(force=True) or {}
+    kind = body.get("kind")
+    if kind == "details":
+        return jsonify({"error": "details 仅支持追加到现有任务"}), 400
+    try:
+        params = _build_run_params(kind, body)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    task = Task(kind, params, name=body.get("name"))
+    with TASKS_LOCK:
+        TASKS[task.id] = task
+    task.persist_meta()
+    try:
+        task.begin_run(kind, params)
+    except RuntimeError as e:
+        return jsonify({"error": str(e)}), 409
+    threading.Thread(target=run_task_thread, args=(task, kind), daemon=True).start()
+    return jsonify({"task_id": task.id, "name": task.name, "cursor": task._cur_run_idx})
+
+
+@app.route("/api/append/<tid>", methods=["POST"])
+def api_append(tid):
+    """对已有任务追加一次运行（kind 自定）。"""
+    body = request.get_json(force=True) or {}
+    kind = body.get("kind")
+    task = TASKS.get(tid)
+    if not task:
+        return jsonify({"error": "not found"}), 404
+    if task.state == "running":
+        return jsonify({"error": "task is running"}), 409
+    try:
+        params = _build_run_params(kind, body)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    try:
+        task.begin_run(kind, params)
+    except RuntimeError as e:
+        return jsonify({"error": str(e)}), 409
+    threading.Thread(target=run_task_thread, args=(task, kind), daemon=True).start()
+    return jsonify({"task_id": task.id, "name": task.name, "cursor": task._cur_run_idx})
+
+
+@app.route("/api/tasks")
+def api_tasks():
+    with TASKS_LOCK:
+        items = [t.to_summary() for t in TASKS.values()]
+    items.sort(key=lambda x: x.get("updated", 0), reverse=True)
+    return jsonify({"items": items})
+
+
+@app.route("/api/task/<tid>")
+def api_task(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(t.to_summary())
+
+
+@app.route("/api/task/<tid>/rename", methods=["POST"])
+def api_rename(tid):
+    body = request.get_json(force=True) or {}
+    name = (body.get("name") or "").strip()
+    if not name:
+        return jsonify({"error": "empty name"}), 400
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    t.name = name[:80]
+    t.updated = time.time()
+    t.persist_meta()
+    return jsonify({"ok": True, "name": t.name})
+
+
+@app.route("/api/task/<tid>", methods=["DELETE"])
+def api_delete(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    if t.state == "running":
+        return jsonify({"error": "task is running"}), 409
+    with TASKS_LOCK:
+        TASKS.pop(tid, None)
+    t.delete_storage()
+    return jsonify({"ok": True})
+
+
+@app.route("/api/notes/<tid>")
+def api_notes(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    offset = int(request.args.get("offset", 0))
+    limit = int(request.args.get("limit", 200))
+    return jsonify({"total": len(t.notes), "items": t.notes[offset : offset + limit]})
+
+
+@app.route("/api/comments/<tid>")
+def api_comments(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    offset = int(request.args.get("offset", 0))
+    limit = int(request.args.get("limit", 200))
+    return jsonify({"total": len(t.comments), "items": t.comments[offset : offset + limit]})
+
+
+@app.route("/api/stop/<tid>", methods=["POST"])
+def api_stop(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    t.stop()
+    return jsonify({"ok": True})
+
+
+@app.route("/api/stream/<tid>")
+def api_stream(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    cursor = int(request.args.get("cursor", 0))
+
+    def gen(task: Task, idx: int):
+        with task.cond:
+            while True:
+                while idx < len(task.events):
+                    yield f"data: {json.dumps(task.events[idx], ensure_ascii=False)}\n\n"
+                    idx += 1
+                # 任务空闲 → 当前 run 结束，关闭流
+                if task.state == "idle":
+                    yield "event: end\ndata: {}\n\n"
+                    return
+                task.cond.wait(timeout=15)
+                if idx >= len(task.events):
+                    yield ": ping\n\n"
+
+    return Response(gen(t, cursor), mimetype="text/event-stream")
+
+
+_ALLOWED_IMG_HOSTS = (
+    "xhscdn.com",
+    "xiaohongshu.com",
+    "xhsstatic.com",
+)
+
+
+@app.route("/api/img")
+def api_img():
+    """图片 / 视频代理，加 Referer 绕过 CDN 校验。"""
+    url = request.args.get("u", "")
+    if not url:
+        return ("", 400)
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.netloc.lower()
+    if not any(host.endswith(d) for d in _ALLOWED_IMG_HOSTS):
+        return ("forbidden host", 400)
+    headers = {
+        "Referer": "https://www.xiaohongshu.com/",
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+        ),
+    }
+    try:
+        upstream = requests.get(url, headers=headers, timeout=20, stream=True)
+    except Exception as e:
+        return (f"upstream error: {e}", 502)
+    ctype = upstream.headers.get("Content-Type", "application/octet-stream")
+    resp = Response(
+        upstream.iter_content(chunk_size=16 * 1024),
+        status=upstream.status_code,
+        content_type=ctype,
+    )
+    resp.headers["Cache-Control"] = "public, max-age=86400"
+    cl = upstream.headers.get("Content-Length")
+    if cl:
+        resp.headers["Content-Length"] = cl
+    return resp
+
+
+@app.route("/api/note/<tid>/<note_id>")
+def api_note_detail(tid, note_id):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    note = next((n for n in t.notes if n.get("note_id") == note_id), None)
+    if not note:
+        return jsonify({"error": "note not in task"}), 404
+    cms = [c for c in t.comments if c.get("note_id") == note_id]
+    # 父评论先，子评论按 parent_comment_id 折叠
+    return jsonify({"note": note, "comments": cms, "count": len(cms)})
+
+
+@app.route("/api/export/<tid>")
+def api_export(tid):
+    t = TASKS.get(tid)
+    if not t:
+        return jsonify({"error": "not found"}), 404
+    kind = request.args.get("kind", "comments")
+    if kind == "comments":
+        if not t.comments:
+            return jsonify({"error": "no comments"}), 400
+        items = t.comments
+        sheet_kind = "comment"
+        prefix = "comments"
+    else:
+        if not t.notes:
+            return jsonify({"error": "no notes"}), 400
+        items = t.notes
+        sheet_kind = "note"
+        prefix = "notes"
+
+    fd, path = tempfile.mkstemp(suffix=".xlsx")
+    os.close(fd)
+    try:
+        save_to_xlsx(items, path, type=sheet_kind)
+        return send_file(
+            path,
+            as_attachment=True,
+            download_name=f"{prefix}_{t.id}.xlsx",
+            mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# ───────────────────────────── boot ─────────────────────────────
+
+
+def _load_persisted_tasks():
+    if not os.path.isdir(STORAGE_DIR):
+        return
+    for name in os.listdir(STORAGE_DIR):
+        d = os.path.join(STORAGE_DIR, name)
+        if not os.path.isdir(d):
+            continue
+        t = Task.load(name)
+        if t:
+            TASKS[t.id] = t
+
+
+_load_persisted_tasks()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=5000)
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+    print(f"\n  小红书采集工具 → http://{args.host}:{args.port}")
+    print(f"  数据目录       → {STORAGE_DIR}")
+    print(f"  历史任务       → {len(TASKS)} 条已加载\n")
+    app.run(host=args.host, port=args.port, debug=args.debug, threaded=True)

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,1189 @@
+/* XHS Field Console — frontend logic */
+(() => {
+  'use strict';
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  const state = {
+    mode: 'comments',
+    rmode: 'notes',
+    taskId: null,             // 当前正在跑的任务 id
+    contextTaskId: null,      // 已载入的历史任务（"追加到该任务" 上下文）
+    contextTaskName: '',
+    history: [],              // 历史任务概要列表
+    es: null,
+    timer: null,
+    startedAt: 0,
+    overall: { value: 0, max: 0 },
+    current: { value: 0, max: 0, indeterminate: false },
+    notesCount: 0,
+    commentsCount: 0,
+    phase: '—',
+    cachedNotes: [],
+    displayedNotes: [],          // cachedNotes 经 filter + sort 后的视图
+    checkedUrls: new Set(),
+    notesFilter: '',
+    notesSort: { col: null, dir: null },
+    cachedComments: [],
+    commentsFilter: '',
+    commentsSort: { col: null, dir: null },
+  };
+
+  // 解析 "1.2万 / 1234 / 1k" 等中英文计数
+  const parseCount = (s) => {
+    s = String(s == null ? '' : s).trim();
+    if (!s || s === '-') return 0;
+    const m = s.match(/^([\d.]+)\s*([万w千k]?)/i);
+    if (!m) return parseFloat(s) || 0;
+    const n = parseFloat(m[1]);
+    const u = (m[2] || '').toLowerCase();
+    if (u === '万' || u === 'w') return n * 10000;
+    if (u === '千' || u === 'k') return n * 1000;
+    return n;
+  };
+
+  // ───────────── helpers ─────────────
+  const fmtTime = (sec) => {
+    sec = Math.max(0, sec);
+    if (sec < 60) return sec.toFixed(1) + 's';
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    return `${m}m ${s}s`;
+  };
+
+  const escHtml = (s) => String(s || '').replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+
+  const truncate = (s, n) => {
+    s = String(s || '');
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+  };
+
+  // 图片代理（绕 Referer 校验）
+  const proxyImg = (url) => {
+    if (!url) return '';
+    if (/^\/?api\/img/.test(url)) return url;
+    if (!/^https?:\/\//i.test(url)) return url;
+    return `/api/img?u=${encodeURIComponent(url)}`;
+  };
+
+  // ───────────── clock ─────────────
+  const tickClock = () => {
+    const d = new Date();
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    const ss = String(d.getSeconds()).padStart(2, '0');
+    $('#clock').textContent = `${hh}:${mm}:${ss}`;
+  };
+  setInterval(tickClock, 1000); tickClock();
+
+  // ───────────── cookie 持久化 ─────────────
+  const COOKIE_KEY = 'xhs_collector_cookie';
+  const cookieInput = $('#cookie-input');
+
+  // 1) 先从 localStorage 恢复
+  const savedCookie = localStorage.getItem(COOKIE_KEY);
+  if (savedCookie && cookieInput) cookieInput.value = savedCookie;
+
+  // 2) 再读 .env 状态作为 placeholder 提示
+  fetch('/api/cookie').then(r => r.json()).then(j => {
+    if (cookieInput && !cookieInput.value) {
+      cookieInput.placeholder = j.has_cookie
+        ? `留空将使用 .env 中的 COOKIES（${j.preview}）`
+        : '.env 未配置，请在此填入并自动保存';
+    }
+  }).catch(() => {});
+
+  // 3) 输入即写回 localStorage（debounce）
+  let cookieSaveTimer = null;
+  cookieInput && cookieInput.addEventListener('input', () => {
+    if (cookieSaveTimer) clearTimeout(cookieSaveTimer);
+    cookieSaveTimer = setTimeout(() => {
+      const v = cookieInput.value.trim();
+      if (v) localStorage.setItem(COOKIE_KEY, v);
+      else localStorage.removeItem(COOKIE_KEY);
+    }, 400);
+  });
+
+  $('#cookie-toggle').addEventListener('click', () => {
+    const inp = $('#cookie-input');
+    const showing = inp.type === 'text';
+    inp.type = showing ? 'password' : 'text';
+    $('#cookie-toggle').textContent = showing ? '显示' : '隐藏';
+  });
+
+  // ───────────── tabs ─────────────
+  $$('.tab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      $$('.tab').forEach(b => b.classList.toggle('is-active', b === btn));
+      const mode = btn.dataset.mode;
+      state.mode = mode;
+      $$('.panel').forEach(p => p.classList.toggle('hidden', p.dataset.panel !== mode));
+      if (mode === 'history') loadHistory();
+    });
+  });
+
+  // ───────────── opt-sub deps ─────────────
+  $$('.opt-toggle input[type="checkbox"]').forEach(cb => {
+    const sync = () => {
+      const sub = $(`.opt-sub[data-deps="${cb.id}"]`);
+      if (sub) sub.classList.toggle('is-on', cb.checked);
+    };
+    cb.addEventListener('change', sync);
+    sync();
+  });
+
+  // ───────────── result tabs ─────────────
+  $$('.rtab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      $$('.rtab').forEach(b => b.classList.toggle('is-active', b === btn));
+      const t = btn.dataset.rtab;
+      state.rmode = t;
+      $$('.rpane').forEach(p => p.classList.toggle('is-active', p.dataset.rpane === t));
+    });
+  });
+
+  // ───────────── feed ─────────────
+  const feedEl = $('#feed');
+  const FEED_MAX = 400;
+
+  const log = (msg, cls = '') => {
+    const li = document.createElement('li');
+    if (cls) li.className = cls;
+    const ts = new Date().toLocaleTimeString('en-GB');
+    li.innerHTML = `<span class="ts">${ts}</span>${msg}`;
+    feedEl.appendChild(li);
+    while (feedEl.children.length > FEED_MAX) feedEl.removeChild(feedEl.firstChild);
+    feedEl.scrollTop = feedEl.scrollHeight;
+  };
+  $('#clear-feed').addEventListener('click', () => { feedEl.innerHTML = ''; });
+
+  // ───────────── progress ─────────────
+  const setOverall = (value, max) => {
+    state.overall = { value, max };
+    const pct = max ? Math.min(100, (value / max) * 100) : 0;
+    const bar = $('#bar-overall');
+    bar.classList.remove('indeterminate');
+    bar.style.width = pct + '%';
+    $('#bar-overall-pct').textContent = max ? `${value} / ${max}` : '—';
+  };
+
+  const setCurrent = (value, max, indeterminate = false) => {
+    state.current = { value, max, indeterminate };
+    const bar = $('#bar-current');
+    if (indeterminate) {
+      bar.classList.add('indeterminate');
+      bar.style.width = '30%';
+      $('#bar-current-pct').textContent = '进行中…';
+    } else {
+      bar.classList.remove('indeterminate');
+      const pct = max ? Math.min(100, (value / max) * 100) : 0;
+      bar.style.width = pct + '%';
+      $('#bar-current-pct').textContent = max ? `${value} / ${max}` : (value ? `${value}` : '—');
+    }
+  };
+
+  const setMetrics = () => {
+    $('#m-phase').textContent = state.phase;
+    $('#m-notes').textContent = state.overall.max
+      ? `${state.overall.value} / ${state.overall.max}`
+      : `${state.notesCount}`;
+    $('#m-comments').textContent = String(state.commentsCount);
+  };
+
+  const setDockState = (txt, running) => {
+    const el = $('#dock-state');
+    el.textContent = txt;
+    el.classList.toggle('is-running', !!running);
+    setRunPill(txt, running);
+  };
+
+  const setRunPill = (txt, running, kind = '') => {
+    const pill = $('#run-pill');
+    if (!pill) return;
+    if (running) {
+      pill.hidden = false;
+      pill.classList.remove('is-stopped', 'is-error');
+      $('#run-pill-text').textContent = txt || '运行中';
+    } else if (kind === 'stopped' || kind === 'error') {
+      pill.hidden = false;
+      pill.classList.toggle('is-stopped', kind === 'stopped');
+      pill.classList.toggle('is-error', kind === 'error');
+      $('#run-pill-text').textContent = txt;
+      // 5 秒后自动消失
+      setTimeout(() => {
+        if ($('#dock-state').textContent.includes(txt)) pill.hidden = true;
+      }, 5000);
+    } else {
+      pill.hidden = true;
+    }
+  };
+
+  // ───────────── results render ─────────────
+  const notesPane = $('.rpane[data-rpane="notes"]');
+  const commentsPane = $('.rpane[data-rpane="comments"]');
+  const notesTable = notesPane.querySelector('table tbody');
+  const commentsTable = commentsPane.querySelector('table tbody');
+
+  const computeDisplayedNotes = () => {
+    let arr = state.cachedNotes;
+    const q = (state.notesFilter || '').trim().toLowerCase();
+    if (q) {
+      arr = arr.filter(n =>
+        String(n.title || '').toLowerCase().includes(q) ||
+        String(n.nickname || '').toLowerCase().includes(q) ||
+        String(n.desc || '').toLowerCase().includes(q)
+      );
+    }
+    const { col, dir } = state.notesSort;
+    if (col && dir) {
+      const NUMERIC = new Set(['liked_count', 'collected_count', 'comment_count']);
+      const sign = dir === 'asc' ? 1 : -1;
+      arr = [...arr].sort((a, b) => {
+        let av = a[col], bv = b[col];
+        if (NUMERIC.has(col)) { av = parseCount(av); bv = parseCount(bv); }
+        else { av = String(av || '').toLowerCase(); bv = String(bv || '').toLowerCase(); }
+        if (av < bv) return -sign;
+        if (av > bv) return sign;
+        return 0;
+      });
+    }
+    state.displayedNotes = arr;
+    return arr;
+  };
+
+  const renderNotes = (items) => {
+    if (items !== undefined) state.cachedNotes = items || [];
+    const displayed = computeDisplayedNotes();
+    const toolbar = notesPane.querySelector('.rpane-toolbar');
+    if (state.cachedNotes.length === 0) {
+      notesPane.querySelector('.empty').style.display = '';
+      notesPane.querySelector('table').hidden = true;
+      if (toolbar) toolbar.hidden = true;
+      $('#rc-notes').textContent = '0';
+      $('#export-notes').disabled = true;
+      return;
+    }
+    notesPane.querySelector('.empty').style.display = 'none';
+    notesPane.querySelector('table').hidden = false;
+    if (toolbar) toolbar.hidden = false;
+    notesTable.innerHTML = '';
+    if (displayed.length === 0) {
+      notesTable.innerHTML = `<tr><td colspan="9" style="text-align:center;color:var(--muted);padding:32px">无匹配（共 ${state.cachedNotes.length} 条）</td></tr>`;
+      $('#rc-notes').textContent = state.cachedNotes.length;
+      $('#export-notes').disabled = false;
+      updateSelection();
+      return;
+    }
+    displayed.forEach((n, i) => {
+      const url = n.note_url || '';
+      const checked = state.checkedUrls.has(url);
+      const cover = n.cover || (Array.isArray(n.image_list) ? n.image_list[0] : '') || '';
+      const title = n.title || '无标题';
+      const desc = n.desc ? truncate(n.desc, 80) : '';
+      const tr = document.createElement('tr');
+      if (checked) tr.classList.add('is-checked');
+      tr.dataset.noteId = n.note_id || '';
+      tr.innerHTML = `
+        <td class="w-check"><input type="checkbox" data-url="${escHtml(url)}" ${checked ? 'checked' : ''}></td>
+        <td class="w-idx">${i + 1}</td>
+        <td class="w-cover">${cover ? `<img src="${escHtml(proxyImg(cover))}" loading="lazy" alt="" referrerpolicy="no-referrer">` : ''}</td>
+        <td>
+          <div class="cell-title">
+            <div class="t">${escHtml(title)}</div>
+            <div class="u">@${escHtml(n.nickname || '匿名')} · ${escHtml(n.note_type || n.type || 'note')}</div>
+            ${desc ? `<div class="u" style="-webkit-line-clamp:1;color:var(--text-2)">${escHtml(desc)}</div>` : ''}
+          </div>
+        </td>
+        <td class="num">${escHtml(n.liked_count || '-')}</td>
+        <td class="num">${escHtml(n.collected_count || '-')}</td>
+        <td class="num">${escHtml(n.comment_count || '-')}</td>
+        <td class="w-time" title="${escHtml(n.upload_time || '')}">${escHtml(n.upload_time || '-')}</td>
+        <td class="w-action">
+          <button class="btn-ghost xs" data-act="preview" data-note-id="${escHtml(n.note_id || '')}">预览</button>
+          <a href="${escHtml(url)}" target="_blank" rel="noopener">原文</a>
+        </td>
+      `;
+      notesTable.appendChild(tr);
+    });
+    $('#rc-notes').textContent = state.cachedNotes.length;
+    $('#export-notes').disabled = state.cachedNotes.length === 0;
+    updateSelection();
+  };
+
+  const updateSelection = () => {
+    const total = state.cachedNotes.length;
+    // 清掉不在当前 cachedNotes 中的勾选（防止跨次任务串扰）
+    const validUrls = new Set(state.cachedNotes.map(n => n.note_url));
+    Array.from(state.checkedUrls).forEach(u => { if (!validUrls.has(u)) state.checkedUrls.delete(u); });
+    const sel = state.checkedUrls.size;
+    $('#notes-sel-count').textContent = String(sel);
+    $('#notes-total').textContent = String(total);
+    const cmtCount = $('#comments-target-count');
+    if (cmtCount) cmtCount.textContent = String(sel);
+    $('#batch-comments').disabled = sel === 0 || !!state.es;
+    const allCb = $('#notes-all'); const allTh = $('#notes-all-th');
+    const allChecked = total > 0 && sel === total;
+    const someChecked = sel > 0 && sel < total;
+    [allCb, allTh].forEach(cb => {
+      if (!cb) return;
+      cb.checked = allChecked;
+      cb.indeterminate = someChecked;
+    });
+    // 待补详情计数（按"选中"优先，无选中则按全部 undetailed）
+    const allUndetailed = state.cachedNotes.filter(n => !n._detailed);
+    const detailTargets = sel > 0
+      ? allUndetailed.filter(n => state.checkedUrls.has(n.note_url))
+      : allUndetailed;
+    const undEl = $('#undetailed-count');
+    const detBtn = $('#batch-details');
+    const targetTid = state.contextTaskId || state.taskId;
+    if (undEl) undEl.textContent = String(detailTargets.length);
+    if (detBtn) {
+      detBtn.disabled = detailTargets.length === 0 || !!state.es || !targetTid;
+      detBtn.title = sel > 0
+        ? `补抓选中且未补全的 ${detailTargets.length} 篇`
+        : `补抓未补全的 ${detailTargets.length} 篇（全部）`;
+    }
+    // batch-comments 同样要求有任务上下文
+    $('#batch-comments').disabled = sel === 0 || !!state.es || !targetTid;
+  };
+
+  const computeDisplayedComments = () => {
+    let arr = state.cachedComments;
+    const q = (state.commentsFilter || '').trim().toLowerCase();
+    if (q) {
+      arr = arr.filter(c =>
+        String(c.content || '').toLowerCase().includes(q) ||
+        String(c.nickname || '').toLowerCase().includes(q) ||
+        String(c.ip_location || '').toLowerCase().includes(q)
+      );
+    }
+    const { col, dir } = state.commentsSort;
+    if (col && dir) {
+      const NUMERIC = new Set(['like_count', 'level']);
+      const sign = dir === 'asc' ? 1 : -1;
+      arr = [...arr].sort((a, b) => {
+        let av = a[col], bv = b[col];
+        if (NUMERIC.has(col)) { av = parseCount(av); bv = parseCount(bv); }
+        else { av = String(av || '').toLowerCase(); bv = String(bv || '').toLowerCase(); }
+        if (av < bv) return -sign;
+        if (av > bv) return sign;
+        return 0;
+      });
+    } else {
+      // 默认：根评论 + 紧随其子，与导出 xlsx 一致
+      arr = [...arr].sort((a, b) => {
+        const aKey = (a.level === 2) ? [String(a.parent_comment_id || ''), 1, String(a.comment_id || '')]
+                                     : [String(a.comment_id || ''), 0, ''];
+        const bKey = (b.level === 2) ? [String(b.parent_comment_id || ''), 1, String(b.comment_id || '')]
+                                     : [String(b.comment_id || ''), 0, ''];
+        for (let i = 0; i < 3; i++) {
+          if (aKey[i] < bKey[i]) return -1;
+          if (aKey[i] > bKey[i]) return 1;
+        }
+        return 0;
+      });
+    }
+    return arr;
+  };
+
+  const renderComments = (items) => {
+    if (items !== undefined) state.cachedComments = items || [];
+    const total = state.cachedComments.length;
+    const tbl = commentsPane.querySelector('table');
+    const toolbar = commentsPane.querySelector('.comments-toolbar');
+    if (total === 0) {
+      commentsPane.querySelector('.empty').style.display = '';
+      tbl.hidden = true;
+      if (toolbar) toolbar.hidden = true;
+      commentsTable.innerHTML = '';
+      $('#rc-comments').textContent = '0';
+      $('#export-comments').disabled = true;
+      return;
+    }
+    commentsPane.querySelector('.empty').style.display = 'none';
+    tbl.hidden = false;
+    if (toolbar) toolbar.hidden = false;
+    const displayed = computeDisplayedComments();
+    const totalEl = $('#comments-total-count');
+    if (totalEl) totalEl.textContent = String(total);
+    commentsTable.innerHTML = '';
+    if (displayed.length === 0) {
+      commentsTable.innerHTML = `<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:32px">无匹配（共 ${total} 条）</td></tr>`;
+    } else {
+      displayed.forEach((c, i) => {
+        const isSub = c.level === 2;
+        const tr = document.createElement('tr');
+        if (isSub) tr.classList.add('is-sub');
+        const lvlTag = `<span class="lvl-tag l-${isSub ? 2 : 1}">${isSub ? '回复' : '根'}</span>`;
+        tr.innerHTML = `
+          <td class="w-idx">${i + 1}</td>
+          <td class="w-level">${lvlTag}</td>
+          <td>
+            <div class="cell-title">
+              <div class="t" style="-webkit-line-clamp:1">@${escHtml(c.nickname || '匿名')}</div>
+              <div class="u">${escHtml(c.user_id || '')}</div>
+            </div>
+          </td>
+          <td class="cell-content-wrap"><div class="cell-content">${escHtml(truncate(c.content, 280))}</div></td>
+          <td class="num">${escHtml(c.like_count || '0')}</td>
+          <td class="w-time">${escHtml(c.upload_time || '')}</td>
+          <td>${escHtml(c.ip_location || '')}</td>
+        `;
+        commentsTable.appendChild(tr);
+      });
+    }
+    $('#rc-comments').textContent = total;
+    $('#export-comments').disabled = false;
+  };
+
+  // notes 表事件代理：勾选 / 全选
+  notesTable.addEventListener('change', (e) => {
+    if (e.target.matches('input[type="checkbox"][data-url]')) {
+      const u = e.target.getAttribute('data-url');
+      if (e.target.checked) state.checkedUrls.add(u);
+      else state.checkedUrls.delete(u);
+      e.target.closest('tr').classList.toggle('is-checked', e.target.checked);
+      updateSelection();
+    }
+  });
+
+  // 筛选输入：debounce 重渲染
+  let filterTimer = null;
+  $('#notes-filter') && $('#notes-filter').addEventListener('input', (e) => {
+    if (filterTimer) clearTimeout(filterTimer);
+    filterTimer = setTimeout(() => {
+      state.notesFilter = e.target.value;
+      renderNotes();
+    }, 180);
+  });
+
+  // 通用列头排序工具
+  const wireSort = (tableEl, sortStateKey, rerender) => {
+    tableEl.addEventListener('click', (e) => {
+      const th = e.target.closest('th[data-sort]');
+      if (!th) return;
+      const col = th.dataset.sort;
+      const cur = state[sortStateKey];
+      let dir;
+      if (cur.col !== col) dir = 'asc';
+      else if (cur.dir === 'asc') dir = 'desc';
+      else if (cur.dir === 'desc') dir = null;
+      else dir = 'asc';
+      state[sortStateKey] = { col: dir ? col : null, dir };
+      tableEl.querySelectorAll('th[data-sort]').forEach(h => h.classList.remove('sort-asc','sort-desc'));
+      if (dir) th.classList.add(dir === 'asc' ? 'sort-asc' : 'sort-desc');
+      rerender();
+    });
+  };
+
+  const notesTableEl = notesPane.querySelector('table');
+  wireSort(notesTableEl, 'notesSort', renderNotes);
+
+  const commentsTableEl = commentsPane.querySelector('table');
+  wireSort(commentsTableEl, 'commentsSort', renderComments);
+
+  // 评论筛选输入
+  let cmtFilterTimer = null;
+  $('#comments-filter') && $('#comments-filter').addEventListener('input', (e) => {
+    if (cmtFilterTimer) clearTimeout(cmtFilterTimer);
+    cmtFilterTimer = setTimeout(() => {
+      state.commentsFilter = e.target.value;
+      renderComments();
+    }, 180);
+  });
+
+  // 点击「预览」按钮打开抽屉（只接 data-act="preview"）
+  notesTable.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-act="preview"]');
+    if (!btn) return;
+    const noteId = btn.dataset.noteId;
+    if (!noteId) return;
+    openNotePreview(noteId);
+  });
+
+  const toggleSelectAll = (checked) => {
+    state.checkedUrls.clear();
+    if (checked) state.cachedNotes.forEach(n => { if (n.note_url) state.checkedUrls.add(n.note_url); });
+    notesTable.querySelectorAll('input[type="checkbox"][data-url]').forEach(cb => {
+      cb.checked = checked;
+      cb.closest('tr').classList.toggle('is-checked', checked);
+    });
+    updateSelection();
+  };
+  // 用 click 事件并显式翻转，避开 indeterminate / change 事件的歧义
+  ['notes-all', 'notes-all-th'].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      const total = state.cachedNotes.length;
+      const sel = state.checkedUrls.size;
+      // 已全选 → 取消；否则 → 全选
+      toggleSelectAll(sel < total);
+    });
+  });
+
+  // 增量取数：每次拉全量列表（仅刷新当前正在跑的任务来源面板）
+  const refreshResults = async (tid) => {
+    tid = tid || state.taskId || state.contextTaskId;
+    if (!tid) return;
+    try {
+      const [n, c] = await Promise.all([
+        fetch(`/api/notes/${tid}?limit=1000`).then(r => r.json()),
+        fetch(`/api/comments/${tid}?limit=2000`).then(r => r.json()),
+      ]);
+      if (n && Array.isArray(n.items)) {
+        state.notesCount = n.total;
+        renderNotes(n.items);
+        $('#export-notes').disabled = n.total === 0;
+      }
+      if (c && Array.isArray(c.items)) {
+        state.commentsCount = c.total;
+        renderComments(c.items);
+        $('#export-comments').disabled = c.total === 0;
+      }
+      setMetrics();
+    } catch (_) {}
+  };
+
+  // ───────────── run task ─────────────
+  const collectParams = (mode) => {
+    const cookies = $('#cookie-input').value.trim();
+    const base = { kind: mode };
+    if (cookies) base.cookies = cookies;
+
+    if (mode === 'comments') {
+      const urls = $('#comments-urls').value
+        .split('\n').map(s => s.trim()).filter(Boolean);
+      const depth = ($$('input[name="cmt-depth"]').find(r => r.checked) || {}).value;
+      base.urls = urls;
+      base.fetch_sub = depth !== 'top';
+    } else if (mode === 'homepage') {
+      base.user_url = $('#homepage-url').value.trim();
+      base.fetch_detail = $('#hp-fetch-detail').checked;
+      base.with_comments = $('#hp-with-comments').checked;
+      const depth = ($$('input[name="hp-depth"]').find(r => r.checked) || {}).value;
+      base.fetch_sub = depth !== 'top';
+    } else if (mode === 'search') {
+      base.query = $('#search-query').value.trim();
+      base.require_num = parseInt($('#search-num').value, 10) || 20;
+      base.sort_type = parseInt($('#search-sort').value, 10);
+      base.note_type = parseInt($('#search-type').value, 10);
+      base.note_time = parseInt($('#search-time').value, 10);
+      base.fetch_detail = $('#sr-fetch-detail').checked;
+      base.with_comments = $('#sr-with-comments').checked;
+      const depth = ($$('input[name="sr-depth"]').find(r => r.checked) || {}).value;
+      base.fetch_sub = depth !== 'top';
+    }
+    return base;
+  };
+
+  const validate = (p) => {
+    if (p.kind === 'comments' && (!p.urls || !p.urls.length)) return '请填入至少一个笔记 URL';
+    if (p.kind === 'homepage' && !p.user_url) return '请填入用户主页 URL';
+    if (p.kind === 'search' && !p.query) return '请填入关键词';
+    return null;
+  };
+
+  const resetProgress = () => {
+    state.phase = '—';
+    setOverall(0, 0);
+    setCurrent(0, 0, false);
+    setMetrics();
+  };
+
+  const startElapsed = () => {
+    state.startedAt = performance.now();
+    if (state.timer) clearInterval(state.timer);
+    state.timer = setInterval(() => {
+      const sec = (performance.now() - state.startedAt) / 1000;
+      $('#m-elapsed').textContent = fmtTime(sec);
+    }, 200);
+  };
+  const stopElapsed = () => {
+    if (state.timer) { clearInterval(state.timer); state.timer = null; }
+  };
+
+  const run = async (mode, override = null, opts = {}) => {
+    if (state.es) {
+      log('已有任务在运行', 'is-warn');
+      return;
+    }
+    const params = override || collectParams(mode);
+    const err = validate(params);
+    if (err) { log(err, 'is-error'); return; }
+
+    feedEl.innerHTML = '';
+    resetProgress();
+
+    // 决定追加目标：opts.appendTo > 显式 context > 无（创建新任务）
+    const appendTo = opts.appendTo || state.contextTaskId;
+    const isAppend = !!appendTo;
+    const modeName = opts.label || (mode === 'comments' ? '评论采集' : mode === 'homepage' ? '主页采集' : '关键词搜索');
+    log(isAppend ? `追加 · ${modeName} → ${state.contextTaskName || appendTo}` : `开始 · ${modeName}`, 'is-phase');
+
+    const url = isAppend ? `/api/append/${appendTo}` : '/api/run';
+    let res;
+    try {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+      });
+      res = await r.json();
+      if (!r.ok) throw new Error(res.error || 'run failed');
+    } catch (e) {
+      log(`派发失败：${e.message}`, 'is-error');
+      return;
+    }
+    state.taskId = res.task_id;
+    if (!isAppend) {
+      // 全新任务：清空显示，绑定为当前任务（在上下文条里展示）
+      state.cachedNotes = [];
+      state.checkedUrls.clear();
+      state.notesCount = 0;
+      state.commentsCount = 0;
+      renderNotes([]);
+      renderComments([]);
+      setContext(res.task_id, res.name);
+    }
+    log(`task_id = ${state.taskId}`);
+    setDockState(isAppend ? '追加运行中' : '运行中', true);
+    $('#stop-btn').disabled = false;
+    setCurrent(0, 0, true);
+    startElapsed();
+    openStream(state.taskId, res.cursor || 0);
+    updateSelection();
+  };
+
+  // 「补全详情」批量按钮 — 优先补"选中"中尚未补的，没选中时补全部
+  $('#batch-details').addEventListener('click', () => {
+    const targetTid = state.contextTaskId || state.taskId;
+    if (!targetTid) { log('当前没有任务可补全', 'is-warn'); return; }
+    const allUndetailed = state.cachedNotes.filter(n => !n._detailed);
+    const targets = state.checkedUrls.size > 0
+      ? allUndetailed.filter(n => state.checkedUrls.has(n.note_url))
+      : allUndetailed;
+    if (targets.length === 0) {
+      log('选中的笔记已全部补全详情', 'is-warn');
+      return;
+    }
+    const cookies = $('#cookie-input').value.trim();
+    const params = { kind: 'details', note_ids: targets.map(n => n.note_id) };
+    if (cookies) params.cookies = cookies;
+    const label = state.checkedUrls.size > 0
+      ? `补全详情 · 选中 ${targets.length} 篇`
+      : `补全详情 · 全部 ${targets.length} 篇`;
+    run('details', params, { appendTo: targetTid, label });
+  });
+
+  // 「采集选中评论」批量按钮 — 始终追加到当前显示的任务
+  $('#batch-comments').addEventListener('click', () => {
+    if (state.checkedUrls.size === 0) return;
+    const targetTid = state.contextTaskId || state.taskId;
+    if (!targetTid) {
+      log('当前没有任务可追加，先采集笔记再来', 'is-warn');
+      return;
+    }
+    const cookies = $('#cookie-input').value.trim();
+    const depth = ($$('input[name="batch-depth"]').find(r => r.checked) || {}).value;
+    const params = {
+      kind: 'comments',
+      urls: Array.from(state.checkedUrls),
+      fetch_sub: depth !== 'top',
+    };
+    if (cookies) params.cookies = cookies;
+    run('comments', params, { appendTo: targetTid, label: `批量评论 · ${state.checkedUrls.size} 篇` });
+  });
+
+  // ───────────── SSE ─────────────
+  const openStream = (tid, cursor = 0) => {
+    const es = new EventSource(`/api/stream/${tid}?cursor=${cursor}`);
+    state.es = es;
+    let pendingRefresh = null;
+    const scheduleRefresh = () => {
+      if (pendingRefresh) return;
+      pendingRefresh = setTimeout(() => {
+        pendingRefresh = null;
+        refreshResults();
+      }, 350);
+    };
+
+    es.onmessage = (msgEvt) => {
+      let evt;
+      try { evt = JSON.parse(msgEvt.data); } catch (_) { return; }
+      handleEvent(evt, scheduleRefresh);
+    };
+    es.addEventListener('end', () => {
+      es.close();
+      state.es = null;
+      stopElapsed();
+      $('#stop-btn').disabled = true;
+      refreshResults();
+      updateSelection();
+    });
+    es.onerror = () => {
+      // 连接关闭即视为终止；手动停止时不会再 reconnect
+      try { es.close(); } catch (_) {}
+      state.es = null;
+      stopElapsed();
+      $('#stop-btn').disabled = true;
+      updateSelection();
+    };
+  };
+
+  const handleEvent = (evt, scheduleRefresh) => {
+    const t = evt.t, p = evt.p || {};
+    if (t === 'task_start') {
+      log(`任务启动`, 'is-success');
+    } else if (t === 'phase') {
+      const name = p.name === 'comments' ? '评论采集'
+        : p.name === 'homepage' ? '主页采集'
+        : p.name === 'search' ? '关键词搜索'
+        : p.name === 'details' ? '采集详情'
+        : p.name;
+      state.phase = name;
+      if (p.total) {
+        setOverall(0, p.total);
+      } else if (p.target) {
+        setOverall(0, p.target);
+      } else {
+        setOverall(0, 0);
+      }
+      const tail = p.total ? ` · ${p.total} 条` : (p.target ? ` · 目标 ${p.target}` : '');
+      log(`阶段：${name}${tail}`, 'is-phase');
+      setMetrics();
+    } else if (t === 'note_index') {
+      setOverall(p.i - 1, p.total);
+      setCurrent(0, 0, true);
+      $('#run-pill-text').textContent = `${state.phase} ${p.i}/${p.total}`;
+      log(`[${p.i}/${p.total}] ${escHtml(truncate(p.url, 88))}`);
+    } else if (t === 'note_start') {
+      log(`  note_id = ${escHtml(p.note_id)}`);
+    } else if (t === 'page') {
+      if (p.kind === 'out') {
+        setCurrent(p.count, 0, true);
+        $('#bar-current-pct').textContent = `一级 ${p.count} 条`;
+      } else if (p.kind === 'inner') {
+        setCurrent(p.count, p.total, false);
+      } else if (p.kind === 'search') {
+        setOverall(p.count, p.total || p.count);
+        setCurrent(p.count, p.total || 0, !p.total);
+        $('#run-pill-text').textContent = `搜索 ${p.count}/${p.total || '?'}`;
+        log(`  搜索第 ${p.page} 页 · ${p.count}/${p.total || '?'}`);
+      } else if (p.kind === 'user_posts') {
+        setCurrent(p.count, 0, true);
+        $('#bar-current-pct').textContent = `已拉 ${p.count} 条笔记`;
+      }
+    } else if (t === 'note_done') {
+      if (p.kind === 'detail') {
+        log(`  详情 · ${p.count}`, 'is-success');
+      } else {
+        log(`  完成 · ${p.count} 条评论`, 'is-success');
+      }
+      scheduleRefresh();
+    } else if (t === 'comments_progress') {
+      state.commentsCount = p.total;
+      setMetrics();
+    } else if (t === 'notes_collected') {
+      state.notesCount = p.count;
+      setMetrics();
+      log(`已收集 ${p.count} 条笔记`, 'is-phase');
+      scheduleRefresh();
+    } else if (t === 'error') {
+      log(escHtml(p.msg || 'error'), 'is-error');
+    } else if (t === 'log') {
+      log(escHtml(p.msg || ''));
+    } else if (t === 'done') {
+      const map = { done: ['完成', 'is-success', ''], stopped: ['已停止', 'is-warn', 'stopped'], error: ['错误', 'is-error', 'error'] };
+      const [finalText, cls, pillKind] = map[p.state] || ['完成', 'is-success', ''];
+      const added = (p.added_notes ? `+${p.added_notes} 笔记` : '') + (p.added_comments ? ` +${p.added_comments} 评论` : '');
+      log(`${finalText} · 共 ${p.notes} 笔记 / ${p.comments} 评论 · ${added.trim() || '无新增'} · ${fmtTime(p.elapsed || 0)}`, cls);
+      setDockState(finalText, false);
+      setRunPill(finalText + ' · ' + (added.trim() || '无新增'), false, pillKind || 'done');
+      if (state.overall.max) setOverall(state.overall.max, state.overall.max);
+      setCurrent(1, 1, false);
+      $('#export-notes').disabled = p.notes === 0;
+      $('#export-comments').disabled = p.comments === 0;
+      updateSelection();
+      loadHistory();
+    }
+  };
+
+  // ───────────── stop & export ─────────────
+  $('#stop-btn').addEventListener('click', async () => {
+    if (!state.taskId) return;
+    try {
+      await fetch(`/api/stop/${state.taskId}`, { method: 'POST' });
+      log('已发出停止指令，等待当前请求结束', 'is-warn');
+    } catch (_) {}
+  });
+
+  const currentResultsTaskId = () => state.contextTaskId || state.taskId;
+  $('#export-notes').addEventListener('click', () => {
+    const tid = currentResultsTaskId();
+    if (tid) window.location.href = `/api/export/${tid}?kind=notes`;
+  });
+  $('#export-comments').addEventListener('click', () => {
+    const tid = currentResultsTaskId();
+    if (tid) window.location.href = `/api/export/${tid}?kind=comments`;
+  });
+
+  // ───────────── primary buttons ─────────────
+  $$('button[data-run]').forEach(b => {
+    b.addEventListener('click', () => run(b.dataset.run));
+  });
+
+  // ───────────── note preview drawer ─────────────
+  const drawer = $('#note-drawer');
+  const drawerBody = $('#drawer-body');
+
+  const openLightbox = (src) => {
+    const lb = document.createElement('div');
+    lb.className = 'lightbox';
+    lb.innerHTML = `<img src="${escHtml(src)}" referrerpolicy="no-referrer" alt="">`;
+    lb.addEventListener('click', () => lb.remove());
+    document.body.appendChild(lb);
+  };
+
+  drawer.addEventListener('click', (e) => {
+    if (e.target.matches('[data-close], .drawer-mask')) closeNotePreview();
+    const im = e.target.closest('.dr-images img, .dr-comment .pics img');
+    if (im) openLightbox(im.src);
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      const lb = document.querySelector('.lightbox');
+      if (lb) { lb.remove(); return; }
+      if (!drawer.hidden) closeNotePreview();
+    }
+  });
+
+  const closeNotePreview = () => { drawer.hidden = true; };
+
+  const openNotePreview = async (noteId) => {
+    const tid = state.contextTaskId || state.taskId;
+    if (!tid) return;
+    drawer.hidden = false;
+    drawerBody.innerHTML = '<div class="empty">加载中…</div>';
+    $('#dr-title').textContent = '笔记预览';
+    $('#dr-open').removeAttribute('href');
+    try {
+      const r = await fetch(`/api/note/${tid}/${encodeURIComponent(noteId)}`).then(r => r.json());
+      if (r.error) throw new Error(r.error);
+      drawerBody.innerHTML = renderNotePreview(r.note, r.comments || []);
+      $('#dr-title').textContent = r.note.title || '无标题';
+      if (r.note.note_url) $('#dr-open').setAttribute('href', r.note.note_url);
+    } catch (e) {
+      drawerBody.innerHTML = `<div class="empty" style="color:var(--danger)">加载失败：${escHtml(e.message)}</div>`;
+    }
+  };
+
+
+  // 渲染笔记预览
+  const renderNotePreview = (n, comments) => {
+    const meta = [
+      ['作者', `@${escHtml(n.nickname || '匿名')}`],
+      ['类型', escHtml(n.note_type || n.type || '—')],
+      ['上传', escHtml(n.upload_time || '—')],
+      ['IP', escHtml(n.ip_location || '—')],
+      ['点赞', escHtml(String(n.liked_count || '0'))],
+      ['收藏', escHtml(String(n.collected_count || '0'))],
+      ['评论', escHtml(String(n.comment_count || '0'))],
+      ['分享', escHtml(String(n.share_count || '0'))],
+    ];
+
+    const metaHtml = meta.map(([k, v]) => `<div><span class="k">${k}</span><span class="v">${v}</span></div>`).join('');
+
+    const desc = n.desc ? `<section class="dr-section"><h4>描述</h4><div class="dr-desc">${escHtml(n.desc)}</div></section>` : '';
+
+    let media = '';
+    if (n.note_type === '视频' && n.video_addr) {
+      const poster = n.video_cover ? proxyImg(n.video_cover) : '';
+      media = `<section class="dr-section"><h4>视频</h4><video class="dr-video" controls preload="metadata" ${poster ? `poster="${escHtml(poster)}"` : ''} src="${escHtml(proxyImg(n.video_addr))}"></video></section>`;
+    } else if (Array.isArray(n.image_list) && n.image_list.length) {
+      const imgs = n.image_list.filter(Boolean).map(u =>
+        `<img src="${escHtml(proxyImg(u))}" loading="lazy" referrerpolicy="no-referrer" alt="">`
+      ).join('');
+      media = `<section class="dr-section"><h4>图集（${n.image_list.length}）</h4><div class="dr-images">${imgs}</div></section>`;
+    }
+
+    const tags = (n.tags && n.tags.length)
+      ? `<section class="dr-section"><h4>标签</h4><div class="dr-tags">${n.tags.map(t => `<span class="dr-tag">#${escHtml(t)}</span>`).join('')}</div></section>`
+      : '';
+
+    // 评论：根 + 子评论嵌套展示
+    const renderOneComment = (c) => {
+      const av = c.avatar
+        ? `<img class="av" src="${escHtml(proxyImg(c.avatar))}" referrerpolicy="no-referrer" alt="">`
+        : '<div class="av"></div>';
+      const pics = (c.pictures && c.pictures.length)
+        ? `<div class="pics">${c.pictures.map(p => `<img src="${escHtml(proxyImg(p))}" referrerpolicy="no-referrer" alt="">`).join('')}</div>`
+        : '';
+      const showTags = (c.show_tags && c.show_tags.length) ? ` · ${escHtml(c.show_tags.join('/'))}` : '';
+      return `
+        <div class="dr-comment">
+          ${av}
+          <div class="body">
+            <div class="top">
+              <span class="nick">@${escHtml(c.nickname || '匿名')}</span>
+              <span class="info">${escHtml(c.upload_time || '')} · ${escHtml(c.ip_location || '')} · ♥ ${escHtml(String(c.like_count || 0))}${showTags}</span>
+            </div>
+            <div class="text">${escHtml(c.content || '')}</div>
+            ${pics}
+          </div>
+        </div>`;
+    };
+
+    const roots = [];
+    const childMap = {};
+    comments.forEach(c => {
+      if (c.level === 2 && c.parent_comment_id) {
+        (childMap[c.parent_comment_id] = childMap[c.parent_comment_id] || []).push(c);
+      } else {
+        roots.push(c);
+      }
+    });
+    // 时间升序
+    const byTime = (a, b) => String(a.upload_time || '').localeCompare(String(b.upload_time || ''));
+    roots.sort(byTime);
+    Object.values(childMap).forEach(arr => arr.sort(byTime));
+
+    const cmtHtml = comments.length === 0
+      ? '<div class="dr-comments-empty">暂无该笔记的评论 — 可在结果页勾选这条笔记后「采集评论」</div>'
+      : roots.map(c => {
+          let html = renderOneComment(c);
+          const subs = childMap[c.comment_id] || [];
+          if (subs.length) {
+            html += `<div class="dr-subs">${subs.map(renderOneComment).join('')}</div>`;
+          }
+          return html;
+        }).join('') +
+        // 兜底：归属错乱的子评论（root 不在当前列表）也单独显示
+        Object.entries(childMap)
+          .filter(([rid]) => !roots.some(r => r.comment_id === rid))
+          .map(([, arr]) => arr.map(renderOneComment).join(''))
+          .join('');
+
+    return `
+      <section class="dr-section">
+        <h4>元信息</h4>
+        <div class="dr-meta">${metaHtml}</div>
+      </section>
+      ${desc}
+      ${media}
+      ${tags}
+      <section class="dr-section">
+        <h4>评论 (${comments.length})</h4>
+        ${cmtHtml}
+      </section>
+    `;
+  };
+
+  // ───────────── history & context ─────────────
+  const fmtTimeAgo = (ts) => {
+    if (!ts) return '—';
+    const sec = Date.now() / 1000 - ts;
+    if (sec < 60) return Math.floor(sec) + ' 秒前';
+    if (sec < 3600) return Math.floor(sec / 60) + ' 分钟前';
+    if (sec < 86400) return Math.floor(sec / 3600) + ' 小时前';
+    return Math.floor(sec / 86400) + ' 天前';
+  };
+  const kindCn = (k) => ({ comments: '评论', homepage: '主页', search: '搜索' }[k] || k);
+
+  const setContext = (tid, name) => {
+    state.contextTaskId = tid;
+    state.contextTaskName = name || '';
+    const bar = $('#context-bar');
+    if (tid) {
+      bar.hidden = false;
+      $('#ctx-name').textContent = name;
+      $('#ctx-meta').textContent = `id ${tid}`;
+    } else {
+      bar.hidden = true;
+    }
+    updateRunButtonLabels();
+    updateBatchButtonHint();
+    // 高亮历史表格中已加载的行
+    $$('#history-tbody tr').forEach(tr => {
+      tr.classList.toggle('is-loaded', tr.dataset.tid === tid);
+    });
+  };
+
+  const updateRunButtonLabels = () => {
+    const text = state.contextTaskId ? '追加到该任务' : '开始采集';
+    $$('button[data-run]').forEach(b => { b.textContent = text; });
+  };
+
+  const updateBatchButtonHint = () => {
+    const btn = $('#batch-comments');
+    if (!btn) return;
+    if (state.contextTaskId) {
+      btn.textContent = '采集选中评论 → 追加';
+      btn.title = `追加到任务 ${state.contextTaskName}`;
+    } else {
+      btn.textContent = '采集选中评论';
+      btn.title = '本次任务结束后自动设为上下文，可继续追加';
+    }
+  };
+
+  // 完整重置 UI 到空闲状态（保留日志、保留 cookie）
+  const resetUI = () => {
+    state.taskId = null;
+    state.cachedNotes = [];
+    state.displayedNotes = [];
+    state.notesFilter = '';
+    state.notesSort = { col: null, dir: null };
+    state.cachedComments = [];
+    state.commentsFilter = '';
+    state.commentsSort = { col: null, dir: null };
+    const fi = $('#notes-filter'); if (fi) fi.value = '';
+    const cfi = $('#comments-filter'); if (cfi) cfi.value = '';
+    notesPane.querySelectorAll('th[data-sort]').forEach(h => h.classList.remove('sort-asc','sort-desc'));
+    commentsPane.querySelectorAll('th[data-sort]').forEach(h => h.classList.remove('sort-asc','sort-desc'));
+    state.checkedUrls.clear();
+    state.notesCount = 0;
+    state.commentsCount = 0;
+    state.phase = '—';
+    state.overall = { value: 0, max: 0 };
+    state.current = { value: 0, max: 0, indeterminate: false };
+    renderNotes([]);
+    renderComments([]);
+    setOverall(0, 0);
+    setCurrent(0, 0, false);
+    setMetrics();
+    setDockState('空闲', false);
+    setRunPill('', false);
+    stopElapsed();
+    $('#m-elapsed').textContent = '0.0s';
+    $('#stop-btn').disabled = true;
+  };
+
+  $('#ctx-clear').addEventListener('click', () => {
+    if (state.es) {
+      log('任务运行中，请先「停止」再新建任务', 'is-warn');
+      return;
+    }
+    setContext(null);
+    resetUI();
+    log('已重置 · 下次操作将创建新任务', 'is-phase');
+  });
+
+  const loadHistory = async () => {
+    try {
+      const r = await fetch('/api/tasks').then(r => r.json());
+      state.history = (r && r.items) || [];
+      $('#history-count').textContent = String(state.history.length);
+      renderHistory();
+    } catch (e) {
+      console.error('loadHistory failed', e);
+      log('加载历史失败：' + (e.message || e), 'is-error');
+    }
+  };
+
+  const renderHistory = () => {
+    const tbody = $('#history-tbody');
+    const tbl = document.querySelector('.history-table');
+    const empty = $('#history-empty');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    if (state.history.length === 0) {
+      tbl.hidden = true;
+      empty.style.display = '';
+      return;
+    }
+    tbl.hidden = false;
+    empty.style.display = 'none';
+    state.history.forEach((t) => {
+      const tr = document.createElement('tr');
+      tr.dataset.tid = t.id;
+      if (t.id === state.contextTaskId) tr.classList.add('is-loaded');
+      tr.innerHTML = `
+        <td>
+          <span class="h-name">${escHtml(t.name)}</span>
+          <span class="h-id">${escHtml(t.id)}</span>
+        </td>
+        <td><span class="kind-tag k-${escHtml(t.kind)}">${escHtml(kindCn(t.kind))}</span></td>
+        <td class="num">${t.notes}</td>
+        <td class="num">${t.comments}</td>
+        <td class="w-runs">${(t.runs || []).length}</td>
+        <td class="h-time" title="${new Date(t.updated * 1000).toLocaleString()}">${fmtTimeAgo(t.updated)}</td>
+        <td class="w-action">
+          <button class="btn-ghost xs" data-act="load">载入</button>
+          <button class="btn-ghost xs" data-act="rename">改名</button>
+          <button class="btn-ghost xs danger" data-act="del">删除</button>
+        </td>
+      `;
+      tbody.appendChild(tr);
+    });
+  };
+
+  $('#refresh-history').addEventListener('click', () => loadHistory());
+
+  $('#history-tbody').addEventListener('click', async (e) => {
+    const tr = e.target.closest('tr');
+    if (!tr) return;
+    const tid = tr.dataset.tid;
+    const t = state.history.find(x => x.id === tid);
+    if (!t) return;
+    const act = e.target.dataset && e.target.dataset.act;
+
+    if (act === 'rename') {
+      const newName = prompt('新的任务名称：', t.name);
+      if (!newName || newName.trim() === '' || newName === t.name) return;
+      await fetch(`/api/task/${tid}/rename`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim() }),
+      });
+      await loadHistory();
+      if (tid === state.contextTaskId) setContext(tid, newName.trim());
+      return;
+    }
+    if (act === 'del') {
+      if (!confirm(`确定删除任务「${t.name}」？\n（数据将从磁盘移除）`)) return;
+      const r = await fetch(`/api/task/${tid}`, { method: 'DELETE' });
+      if (r.ok) {
+        if (tid === state.contextTaskId) setContext(null);
+        await loadHistory();
+      } else {
+        const j = await r.json().catch(() => ({}));
+        log(`删除失败：${j.error || r.status}`, 'is-error');
+      }
+      return;
+    }
+
+    // 默认动作：载入
+    await loadTaskAsContext(tid, t.name);
+  });
+
+  const loadTaskAsContext = async (tid, name) => {
+    setContext(tid, name);
+    state.taskId = tid;            // ← 同步设为当前任务，否则批量按钮的启用判断会失效
+    state.cachedNotes = [];
+    state.checkedUrls.clear();
+    feedEl.innerHTML = '';
+    log(`已载入任务 ${name}`, 'is-phase');
+    await refreshResults(tid);
+    setMetrics();
+    // 切回评论 tab，方便用户立刻追加评论
+    const targetTab = $$('.tab').find(b => b.dataset.mode === 'comments');
+    if (targetTab) targetTab.click();
+  };
+
+  // initial render
+  setOverall(0, 0);
+  setCurrent(0, 0, false);
+  setMetrics();
+  setDockState('空闲', false);
+  log('就绪', 'is-phase');
+  updateSelection();
+  updateRunButtonLabels();
+  updateBatchButtonHint();
+  loadHistory();
+})();

--- a/web/static/home.css
+++ b/web/static/home.css
@@ -1,0 +1,113 @@
+/* 工具集首页 */
+
+.home-page .topbar { justify-content: space-between; }
+
+.home-main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 24px;
+}
+
+.home-intro {
+  margin-bottom: 28px;
+}
+.home-intro h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--text);
+}
+.home-intro p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+}
+
+.tool-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  cursor: pointer;
+  --c-accent: var(--accent);
+  --c-accent-soft: var(--accent-soft);
+}
+.tool-card:hover {
+  border-color: var(--c-accent);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.tool-icon {
+  width: 48px;
+  height: 48px;
+  background: var(--c-accent-soft);
+  color: var(--c-accent);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  flex-shrink: 0;
+}
+
+.tool-info {
+  flex: 1;
+  min-width: 0;
+}
+.tool-name {
+  font-weight: 600;
+  font-size: 14.5px;
+  color: var(--text);
+  margin-bottom: 3px;
+}
+.tool-desc {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.tool-url {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted-2);
+  margin-top: 4px;
+}
+
+.tool-arrow {
+  color: var(--muted);
+  font-size: 18px;
+  transition: transform 0.15s, color 0.15s;
+}
+.tool-card:hover .tool-arrow {
+  transform: translateX(4px);
+  color: var(--c-accent);
+}
+
+.tool-card.placeholder {
+  cursor: default;
+  border-style: dashed;
+  background: transparent;
+  opacity: 0.7;
+}
+.tool-card.placeholder:hover {
+  transform: none;
+  border-color: var(--border-2);
+  box-shadow: none;
+}
+.tool-card.placeholder .tool-icon {
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 22px;
+  font-weight: 300;
+}

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1,0 +1,979 @@
+/* 小红书采集工具 — 简洁工具风 */
+
+:root {
+  --bg: #FAFAF8;
+  --surface: #FFFFFF;
+  --surface-2: #F5F5F2;
+  --border: #E5E5E1;
+  --border-2: #D4D4CF;
+  --text: #1A1A1A;
+  --text-2: #4A4A48;
+  --muted: #8A8A85;
+  --muted-2: #B5B5B0;
+
+  --accent: #2563EB;
+  --accent-soft: #EFF4FF;
+  --danger: #DC2626;
+  --danger-soft: #FEF2F2;
+  --success: #16A34A;
+  --warning: #D97706;
+
+  --sans: system-ui, -apple-system, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+
+  --radius: 6px;
+  --radius-sm: 4px;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+/* 兜底：任何元素带 [hidden] 都必须真的隐藏（盖过 .drawer / .context-bar 等 display:flex） */
+[hidden] { display: none !important; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+.muted { color: var(--muted); }
+
+/* ── topbar ─────────────────────────────── */
+.topbar {
+  height: 48px;
+  padding: 0 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.topbar-back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-right: 6px;
+  border-radius: 6px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 18px;
+  line-height: 1;
+  transition: background 0.15s, color 0.15s;
+}
+.topbar-back:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.topbar-meta {
+  font-size: 12px;
+  color: var(--text-2);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.topbar-meta .sep { color: var(--muted-2); }
+
+.run-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px 3px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 500;
+  border: 1px solid #BFD6FE;
+}
+.run-pill .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: blink 1.2s steps(2) infinite;
+}
+.run-pill.is-stopped { background: #FEF3C7; color: var(--warning); border-color: #FDE68A; }
+.run-pill.is-stopped .dot { background: var(--warning); animation: none; }
+.run-pill.is-error { background: var(--danger-soft); color: var(--danger); border-color: #FCA5A5; }
+.run-pill.is-error .dot { background: var(--danger); animation: none; }
+
+/* ── tabs ───────────────────────────────── */
+.tabs {
+  display: flex;
+  gap: 0;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0 12px;
+}
+
+.tab {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--text-2);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -1px;
+}
+
+.tab:hover { color: var(--text); }
+.tab.is-active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  font-weight: 500;
+}
+
+.tab-badge {
+  display: inline-block;
+  margin-left: 4px;
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 11px;
+  padding: 0 6px;
+  border-radius: 10px;
+  min-width: 18px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  font-weight: 400;
+}
+.tab.is-active .tab-badge { background: var(--accent-soft); color: var(--accent); }
+
+/* ── context bar ────────────────────────── */
+.context-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 20px;
+  background: #FEF6E7;
+  border-bottom: 1px solid #F3D98A;
+  font-size: 12.5px;
+}
+.context-bar .ctx-label {
+  color: var(--warning);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.context-bar .ctx-name { color: var(--text); font-weight: 500; }
+.context-bar .ctx-meta { font-size: 11.5px; }
+.context-bar #ctx-clear { margin-left: auto; }
+
+/* ── history table ──────────────────────── */
+.history-body { max-height: 560px; overflow: auto; }
+.history-table { font-size: 12.5px; }
+.history-table tbody tr { cursor: pointer; }
+.history-table tbody tr.is-loaded td { background: var(--accent-soft); }
+.history-table tbody tr.is-loaded:hover td { background: #E0EAFE; }
+.history-table .w-kind { width: 80px; }
+.history-table .w-runs { width: 80px; text-align: center; }
+.table.history-table .w-action {
+  width: 220px;
+  text-align: right;
+  white-space: nowrap;
+}
+.table.history-table .w-action button {
+  margin-left: 4px;
+  display: inline-block;
+}
+.history-table .kind-tag {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 3px;
+  font-size: 11px;
+  background: var(--surface-2);
+  color: var(--text-2);
+  border: 1px solid var(--border);
+}
+.history-table .kind-tag.k-comments { color: var(--accent); border-color: #BFD6FE; background: var(--accent-soft); }
+.history-table .kind-tag.k-homepage { color: var(--success); border-color: #BBE2C7; background: #ECF7EF; }
+.history-table .kind-tag.k-search { color: var(--warning); border-color: #F3D98A; background: #FEF6E7; }
+.history-table .h-name { color: var(--text); font-weight: 500; }
+.history-table .h-id { font-family: var(--mono); color: var(--muted); font-size: 10.5px; margin-left: 6px; }
+.history-table .h-time { color: var(--text-2); font-variant-numeric: tabular-nums; }
+
+/* ── layout ─────────────────────────────── */
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 16px;
+  padding: 16px 20px;
+  align-items: start;
+}
+
+.left { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: sticky;
+  top: 16px;
+}
+
+/* ── card ───────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.card-head {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.card-head h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+.card-head h3 {
+  font-size: 12px;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+.card-head .hint {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+  font-weight: normal;
+}
+.card-head h2 + .hint { margin-left: 8px; }
+.card-head.with-tabs { padding: 4px 8px 4px 16px; }
+.card-actions { margin-left: auto; display: flex; gap: 6px; }
+
+.card-body { padding: 14px 16px; }
+
+.cookie-card .row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+}
+.cookie-card .lbl {
+  font-size: 12px;
+  color: var(--text-2);
+  flex-shrink: 0;
+  min-width: 48px;
+}
+.cookie-card input { flex: 1; }
+
+/* ── panel ──────────────────────────────── */
+.panel.hidden { display: none; }
+.panel .card-body { display: flex; flex-direction: column; gap: 14px; }
+
+/* ── fields ─────────────────────────────── */
+.field { display: flex; flex-direction: column; gap: 4px; }
+.lbl {
+  font-size: 11.5px;
+  color: var(--text-2);
+  font-weight: 500;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"],
+textarea,
+select {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+}
+
+textarea {
+  font-family: var(--mono);
+  font-size: 12px;
+  resize: vertical;
+  min-height: 110px;
+  line-height: 1.55;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6'><path d='M0 0l5 6 5-6z' fill='%238A8A85'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.grid .span-all { grid-column: 1 / -1; }
+
+/* ── opts ───────────────────────────────── */
+.opts {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  display: inline-flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.opts legend.lbl {
+  margin-right: 8px;
+  padding: 0;
+}
+
+.opts-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+.opt input { margin: 0; cursor: pointer; accent-color: var(--accent); }
+
+.opt-toggle {
+  padding-right: 12px;
+  border-right: 1px solid var(--border);
+}
+
+.opt-sub { opacity: 0.4; pointer-events: none; transition: opacity 0.15s; }
+.opt-sub.is-on { opacity: 1; pointer-events: auto; }
+
+/* ── actions / buttons ──────────────────── */
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.btn-primary {
+  background: var(--text);
+  color: #fff;
+  border: 0;
+  padding: 7px 16px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background 0.15s;
+}
+.btn-primary:hover:not(:disabled) { background: #000; }
+.btn-primary:disabled {
+  background: var(--muted-2);
+  cursor: not-allowed;
+}
+
+.btn-ghost {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-2);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+.btn-ghost:hover:not(:disabled) {
+  border-color: var(--border-2);
+  background: var(--surface-2);
+  color: var(--text);
+}
+.btn-ghost:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-ghost.xs { padding: 3px 8px; font-size: 11.5px; }
+.btn-ghost.danger { color: var(--danger); border-color: #FCA5A5; }
+.btn-ghost.danger:hover:not(:disabled) { background: var(--danger-soft); border-color: var(--danger); color: var(--danger); }
+
+/* ── results ────────────────────────────── */
+.result-tabs { display: flex; gap: 2px; }
+
+.rtab {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 6px 12px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: color 0.15s, background 0.15s;
+}
+.rtab:hover { color: var(--text); }
+.rtab.is-active { color: var(--text); font-weight: 500; background: var(--surface-2); }
+
+.badge {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 20px;
+  text-align: center;
+}
+.rtab.is-active .badge { background: var(--surface); color: var(--text-2); }
+
+.results-body { max-height: 520px; overflow: auto; }
+
+.hint-inline {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+/* notes batch toolbar */
+.rpane-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+  flex-wrap: wrap;
+  font-size: 12px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+.rpane-toolbar .sep { color: var(--muted-2); }
+.rpane-toolbar .opts { gap: 12px; }
+.rpane-toolbar .opts legend.lbl { margin-right: 4px; }
+.rpane-toolbar #batch-comments { margin-left: auto; }
+.btn-primary.xs { padding: 5px 12px; font-size: 12px; }
+
+/* notes table check column */
+.table .w-check { width: 32px; padding-right: 0; }
+.table .w-check input { margin: 0; cursor: pointer; accent-color: var(--accent); }
+.table tbody tr.is-checked td { background: var(--accent-soft); }
+.table tbody tr.is-checked:hover td { background: #E0EAFE; }
+
+/* sortable column headers */
+.table thead th[data-sort] { cursor: pointer; user-select: none; }
+.table thead th[data-sort]:hover { color: var(--text); background: var(--border); }
+.table thead th[data-sort]::after {
+  content: " ⇵";
+  opacity: 0.3;
+  font-size: 9.5px;
+  display: inline-block;
+  margin-left: 2px;
+}
+.table thead th[data-sort].sort-asc::after  { content: " ↑"; opacity: 1; color: var(--accent); }
+.table thead th[data-sort].sort-desc::after { content: " ↓"; opacity: 1; color: var(--accent); }
+
+/* filter input in toolbar */
+.rpane-toolbar .filter-input {
+  flex: 1;
+  min-width: 140px;
+  max-width: 240px;
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.rpane { display: none; }
+.rpane.is-active { display: block; }
+
+.empty {
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+  padding: 56px 16px;
+}
+.empty code {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+
+.table thead th {
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-weight: 500;
+  font-size: 11.5px;
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  white-space: nowrap;
+}
+
+.table tbody td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  vertical-align: middle;
+}
+.table tbody tr:hover td { background: var(--surface-2); }
+.table tbody tr:last-child td { border-bottom: 0; }
+
+.table .w-idx { width: 40px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.table .w-cover { width: 56px; }
+.table .w-cover img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  display: block;
+  border: 1px solid var(--border);
+}
+.table .num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  width: 64px;
+  color: var(--text-2);
+}
+.table .w-time {
+  width: 130px;
+  white-space: nowrap;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-2);
+}
+.table .w-level { width: 38px; text-align: center; }
+.lvl-tag {
+  display: inline-block;
+  min-width: 18px;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 10.5px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-2);
+}
+.lvl-tag.l-2 { background: var(--accent-soft); color: var(--accent); border-color: #BFD6FE; }
+.comments-table tbody tr.is-sub td.cell-content-wrap { padding-left: 28px; }
+.comments-table tbody tr.is-sub td.cell-content-wrap::before {
+  content: "↳ ";
+  color: var(--muted);
+  margin-right: 4px;
+}
+.table .w-action {
+  width: 130px;
+  text-align: right;
+  white-space: nowrap;
+}
+.table .w-action button { margin-right: 6px; }
+.table .w-action a {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 12px;
+}
+.table .w-action a:hover { text-decoration: underline; }
+
+.cell-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 460px;
+}
+.cell-title .t {
+  color: var(--text);
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.cell-title .u {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+.cell-content {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  max-width: 520px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+/* ── status / progress ──────────────────── */
+.status-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--surface-2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  margin-left: auto;
+}
+.status-badge.is-running {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: #BFD6FE;
+}
+.status-badge.is-running::before {
+  content: "●";
+  margin-right: 4px;
+  animation: blink 1.2s steps(2) infinite;
+}
+@keyframes blink { 50% { opacity: 0.3; } }
+
+.status-body { display: flex; flex-direction: column; gap: 14px; }
+
+.metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.metric {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.m-key {
+  font-size: 11px;
+  color: var(--muted);
+}
+.m-val {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.bars { display: flex; flex-direction: column; gap: 10px; }
+.bar { display: flex; flex-direction: column; gap: 4px; }
+.bar-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11.5px;
+  color: var(--text-2);
+}
+.bar-track {
+  position: relative;
+  height: 4px;
+  background: var(--surface-2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0%;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width 0.25s ease;
+}
+.bar-fill.alt { background: var(--success); }
+.bar-fill.indeterminate {
+  width: 30% !important;
+  animation: indet 1.2s ease-in-out infinite;
+}
+@keyframes indet {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(330%); }
+}
+
+/* ── log ────────────────────────────────── */
+.log-card .card-head h3 + button { margin-left: auto; }
+
+.feed {
+  list-style: none;
+  margin: 0;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-family: var(--mono);
+  color: var(--text);
+  max-height: 280px;
+  overflow-y: auto;
+  line-height: 1.6;
+}
+.feed li {
+  padding: 1px 0;
+  display: flex;
+  gap: 8px;
+}
+.feed li .ts {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.feed li.is-error { color: var(--danger); }
+.feed li.is-success { color: var(--success); }
+.feed li.is-warn { color: var(--warning); }
+.feed li.is-phase {
+  color: var(--text);
+  font-weight: 600;
+  margin-top: 4px;
+  border-top: 1px dashed var(--border);
+  padding-top: 5px;
+}
+.feed li.is-phase:first-child { border-top: 0; margin-top: 0; padding-top: 1px; }
+
+.feed::-webkit-scrollbar,
+.results-body::-webkit-scrollbar { width: 8px; height: 8px; }
+.feed::-webkit-scrollbar-track,
+.results-body::-webkit-scrollbar-track { background: transparent; }
+.feed::-webkit-scrollbar-thumb,
+.results-body::-webkit-scrollbar-thumb {
+  background: var(--border-2);
+  border-radius: 4px;
+}
+
+/* ── drawer (note preview) ──────────────── */
+.drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: flex-end;
+}
+.drawer-mask {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 14, 12, 0.4);
+  backdrop-filter: blur(2px);
+  animation: fade-in 0.2s ease;
+}
+.drawer-panel {
+  position: relative;
+  width: min(760px, 90%);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.18);
+  animation: slide-in 0.25s cubic-bezier(.2,.8,.2,1);
+}
+@keyframes slide-in { from { transform: translateX(40px); opacity: 0.4; } to { transform: none; opacity: 1; } }
+@keyframes fade-in  { from { opacity: 0; } to { opacity: 1; } }
+
+.drawer-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.drawer-head h3 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.dr-section { margin-bottom: 20px; }
+.dr-section h4 {
+  margin: 0 0 8px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.dr-meta {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px 14px;
+  font-size: 12.5px;
+}
+.dr-meta .k { color: var(--muted); margin-right: 6px; }
+.dr-meta .v { color: var(--text); }
+.dr-desc {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  font-size: 13px;
+  white-space: pre-wrap;
+  line-height: 1.6;
+  max-height: 240px;
+  overflow-y: auto;
+}
+.dr-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.dr-tag {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11.5px;
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+.dr-images {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+}
+.dr-images img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  cursor: zoom-in;
+  background: var(--surface-2);
+}
+.dr-video {
+  width: 100%;
+  max-height: 420px;
+  border-radius: var(--radius-sm);
+  background: #000;
+}
+.dr-comments-empty {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 12.5px;
+  padding: 12px 0;
+}
+.dr-comment {
+  display: flex;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--border);
+}
+.dr-comment:last-child { border-bottom: 0; }
+.dr-comment .av {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--surface-2);
+  flex-shrink: 0;
+}
+.dr-comment .body { flex: 1; min-width: 0; }
+.dr-comment .top {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.dr-comment .nick { font-weight: 500; font-size: 12.5px; }
+.dr-comment .info { color: var(--muted); font-size: 11px; }
+.dr-comment .text {
+  margin-top: 3px;
+  font-size: 13px;
+  line-height: 1.55;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+.dr-comment .pics {
+  margin-top: 6px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.dr-comment .pics img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  cursor: zoom-in;
+}
+.dr-subs {
+  margin-top: 8px;
+  margin-left: 42px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
+}
+
+/* light-box for image zoom */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0,0,0,0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: zoom-out;
+  animation: fade-in 0.15s;
+}
+.lightbox img { max-width: 92vw; max-height: 92vh; box-shadow: 0 8px 40px rgba(0,0,0,0.5); }
+
+/* ── footer ─────────────────────────────── */
+.ftr {
+  text-align: center;
+  padding: 20px;
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+/* ── responsive ─────────────────────────── */
+@media (max-width: 1100px) {
+  .layout { grid-template-columns: 1fr; }
+  .right { position: static; }
+  .grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .layout { padding: 12px; }
+  .grid { grid-template-columns: 1fr; }
+  .metrics { grid-template-columns: 1fr; }
+}

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>数据采集工具集</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='home.css') }}" />
+</head>
+<body class="home-page">
+  <header class="topbar">
+    <div class="brand">数据采集工具集</div>
+    <div class="topbar-meta">
+      <span class="muted">{{ tools|length }} 个工具</span>
+    </div>
+  </header>
+
+  <main class="home-main">
+    <section class="home-intro">
+      <h1>选择一个工具开始</h1>
+      <p class="muted">点击卡片进入对应平台的数据采集工具</p>
+    </section>
+
+    <section class="tools-grid">
+      {% for t in tools %}
+      <a class="tool-card" href="{{ t.url }}"
+         style="--c-accent: {{ t.color }}; --c-accent-soft: {{ t.color_soft }};">
+        <div class="tool-icon">{{ t.icon }}</div>
+        <div class="tool-info">
+          <div class="tool-name">{{ t.name }}</div>
+          <div class="tool-desc">{{ t.desc }}</div>
+          <div class="tool-url">{{ t.url }}</div>
+        </div>
+        <div class="tool-arrow">→</div>
+      </a>
+      {% endfor %}
+
+      <div class="tool-card placeholder">
+        <div class="tool-icon">+</div>
+        <div class="tool-info">
+          <div class="tool-name">更多工具</div>
+          <div class="tool-desc">在 server.py 的 TOOLS 中追加配置项即可接入新平台</div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="ftr">
+    <span>仅供学习交流，禁止商业用途</span>
+  </footer>
+</body>
+</html>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>小红书采集工具</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+</head>
+<body>
+  <header class="topbar">
+    <a href="/" class="topbar-back" title="返回首页">←</a>
+    <div class="brand">小红书采集工具</div>
+    <div class="topbar-meta">
+      <span id="run-pill" class="run-pill" hidden>
+        <span class="dot"></span>
+        <span id="run-pill-text">运行中</span>
+      </span>
+      <span id="clock" class="muted">--:--:--</span>
+    </div>
+  </header>
+
+  <nav class="tabs">
+    <button class="tab is-active" data-mode="comments">评论采集</button>
+    <button class="tab" data-mode="homepage">主页采集</button>
+    <button class="tab" data-mode="search">关键词搜索</button>
+    <button class="tab" data-mode="history">历史任务 <span id="history-count" class="tab-badge">0</span></button>
+  </nav>
+
+  <div class="context-bar" id="context-bar" hidden>
+    <span class="ctx-label">当前任务</span>
+    <span class="ctx-name" id="ctx-name">—</span>
+    <span class="ctx-meta muted" id="ctx-meta"></span>
+    <button class="btn-ghost xs" id="ctx-clear">新建任务（清空当前）</button>
+  </div>
+
+  <main class="layout">
+
+    <section class="left">
+      <!-- shared cookie -->
+      <div class="card cookie-card">
+        <label class="row">
+          <span class="lbl">Cookie</span>
+          <input id="cookie-input" type="password" placeholder="留空使用 .env 中的 COOKIES" />
+          <button class="btn-ghost xs" id="cookie-toggle" type="button">显示</button>
+        </label>
+      </div>
+
+      <!-- panel: comments -->
+      <article class="card panel" data-panel="comments">
+        <div class="card-head">
+          <h2>评论采集</h2>
+          <p class="hint">粘贴笔记 URL，每行一个；分页拉取评论流。</p>
+        </div>
+        <div class="card-body">
+          <label class="field">
+            <span class="lbl">笔记 URL（每行一个）</span>
+            <textarea id="comments-urls" rows="6" placeholder="https://www.xiaohongshu.com/explore/…?xsec_token=…"></textarea>
+          </label>
+          <fieldset class="opts">
+            <legend class="lbl">评论范围</legend>
+            <label class="opt"><input type="radio" name="cmt-depth" value="all" checked /> 一级 + 二级</label>
+            <label class="opt"><input type="radio" name="cmt-depth" value="top" /> 仅一级</label>
+          </fieldset>
+          <div class="actions">
+            <button class="btn-primary" data-run="comments">开始采集</button>
+          </div>
+        </div>
+      </article>
+
+      <!-- panel: homepage -->
+      <article class="card panel hidden" data-panel="homepage">
+        <div class="card-head">
+          <h2>主页采集</h2>
+          <p class="hint">输入用户主页 URL，拉全部已发布笔记；可勾选连带采评论。</p>
+        </div>
+        <div class="card-body">
+          <label class="field">
+            <span class="lbl">用户主页 URL</span>
+            <input id="homepage-url" type="text" placeholder="https://www.xiaohongshu.com/user/profile/…" />
+          </label>
+          <div class="opts-row">
+            <label class="opt"><input type="checkbox" id="hp-fetch-detail" checked /> 采集完整详情</label>
+            <label class="opt opt-toggle">
+              <input type="checkbox" id="hp-with-comments" /> 连带采评论
+            </label>
+            <fieldset class="opts opt-sub" data-deps="hp-with-comments">
+              <label class="opt"><input type="radio" name="hp-depth" value="all" checked /> 一级 + 二级</label>
+              <label class="opt"><input type="radio" name="hp-depth" value="top" /> 仅一级</label>
+            </fieldset>
+          </div>
+          <div class="actions">
+            <button class="btn-primary" data-run="homepage">开始采集</button>
+            <span class="muted hint-inline">未勾选"连带采评论"时，可在结果中勾选笔记后批量采集</span>
+          </div>
+        </div>
+      </article>
+
+      <!-- panel: search -->
+      <article class="card panel hidden" data-panel="search">
+        <div class="card-head">
+          <h2>关键词搜索</h2>
+          <p class="hint">先按关键词检索笔记列表，可选立即对结果批量采评论。</p>
+        </div>
+        <div class="card-body">
+          <div class="grid">
+            <label class="field span-all">
+              <span class="lbl">关键词</span>
+              <input id="search-query" type="text" placeholder="榴莲 / 露营 …" />
+            </label>
+            <label class="field">
+              <span class="lbl">数量</span>
+              <input id="search-num" type="number" min="1" max="200" value="20" />
+            </label>
+            <label class="field">
+              <span class="lbl">排序</span>
+              <select id="search-sort">
+                <option value="0">综合</option>
+                <option value="1">最新</option>
+                <option value="2">最多点赞</option>
+                <option value="3">最多评论</option>
+                <option value="4">最多收藏</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="lbl">类型</span>
+              <select id="search-type">
+                <option value="0">不限</option>
+                <option value="1">视频</option>
+                <option value="2">图文</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="lbl">时间</span>
+              <select id="search-time">
+                <option value="0">不限</option>
+                <option value="1">一天内</option>
+                <option value="2">一周内</option>
+                <option value="3">半年内</option>
+              </select>
+            </label>
+          </div>
+          <div class="opts-row">
+            <label class="opt"><input type="checkbox" id="sr-fetch-detail" checked /> 采集完整详情</label>
+            <label class="opt opt-toggle">
+              <input type="checkbox" id="sr-with-comments" /> 连带采评论（全部）
+            </label>
+            <fieldset class="opts opt-sub" data-deps="sr-with-comments">
+              <label class="opt"><input type="radio" name="sr-depth" value="all" checked /> 一级 + 二级</label>
+              <label class="opt"><input type="radio" name="sr-depth" value="top" /> 仅一级</label>
+            </fieldset>
+          </div>
+          <div class="actions">
+            <button class="btn-primary" data-run="search">开始采集</button>
+            <span class="muted hint-inline">检索完成后可在结果中勾选目标笔记，再批量采评论</span>
+          </div>
+        </div>
+      </article>
+
+      <!-- panel: history -->
+      <article class="card panel hidden" data-panel="history">
+        <div class="card-head">
+          <h2>历史任务</h2>
+          <p class="hint">点击行可载入到结果面板，再切回上方任意 tab 可向其追加抓取。</p>
+          <button class="btn-ghost xs" id="refresh-history" style="margin-left:auto">刷新</button>
+        </div>
+        <div class="history-body">
+          <div class="empty" id="history-empty">
+            <div>尚无历史任务</div>
+            <div style="margin-top:8px;font-size:12px;color:var(--muted-2)">
+              在「评论 / 主页 / 关键词」面板启动一次采集，任务结束后会自动出现在这里。<br/>
+              所有任务持久化在 <code>data/tasks/</code> 目录，重启服务后仍然可见。
+            </div>
+          </div>
+          <table class="table history-table" hidden>
+            <thead>
+              <tr>
+                <th>名称</th>
+                <th class="w-kind">类型</th>
+                <th class="num">笔记</th>
+                <th class="num">评论</th>
+                <th class="w-runs">运行次数</th>
+                <th>更新时间</th>
+                <th class="w-action"></th>
+              </tr>
+            </thead>
+            <tbody id="history-tbody"></tbody>
+          </table>
+        </div>
+      </article>
+
+      <!-- results -->
+      <section class="card results">
+        <header class="card-head with-tabs">
+          <div class="result-tabs">
+            <button class="rtab is-active" data-rtab="notes">笔记 <span class="badge" id="rc-notes">0</span></button>
+            <button class="rtab" data-rtab="comments">评论 <span class="badge" id="rc-comments">0</span></button>
+          </div>
+          <div class="card-actions">
+            <button class="btn-ghost" id="export-notes" disabled>导出笔记 .xlsx</button>
+            <button class="btn-ghost" id="export-comments" disabled>导出评论 .xlsx</button>
+          </div>
+        </header>
+        <div class="results-body">
+          <div class="rpane is-active" data-rpane="notes">
+            <div class="empty">尚无笔记</div>
+            <div class="rpane-toolbar" hidden>
+              <label class="opt">
+                <input type="checkbox" id="notes-all" /> 全选
+              </label>
+              <span class="muted">已选 <span id="notes-sel-count">0</span> / <span id="notes-total">0</span></span>
+              <input type="text" id="notes-filter" class="filter-input" placeholder="搜索标题 / 用户 / 描述..." />
+              <span class="sep">·</span>
+              <fieldset class="opts" title="决定「采集评论」按钮拉取的评论层级">
+                <legend class="lbl">评论范围</legend>
+                <label class="opt"><input type="radio" name="batch-depth" value="all" checked /> 一级 + 二级</label>
+                <label class="opt"><input type="radio" name="batch-depth" value="top" /> 仅一级</label>
+              </fieldset>
+              <button class="btn-primary xs" id="batch-comments" disabled title="采集选中笔记的评论（按上方"评论范围"控制层级）">
+                采集评论 <span id="comments-target-count" class="badge">0</span>
+              </button>
+              <button class="btn-ghost xs" id="batch-details" disabled title="补抓选中且未完成的笔记详情">
+                补全详情 <span id="undetailed-count" class="badge">0</span>
+              </button>
+            </div>
+            <table class="table notes-table" hidden>
+              <thead>
+                <tr>
+                  <th class="w-check"><input type="checkbox" id="notes-all-th" /></th>
+                  <th class="w-idx">#</th>
+                  <th class="w-cover">封面</th>
+                  <th data-sort="title">标题 / 用户</th>
+                  <th class="num" data-sort="liked_count">点赞</th>
+                  <th class="num" data-sort="collected_count">收藏</th>
+                  <th class="num" data-sort="comment_count">评论</th>
+                  <th class="w-time" data-sort="upload_time">时间</th>
+                  <th class="w-action"></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div class="rpane" data-rpane="comments">
+            <div class="empty">尚无评论</div>
+            <div class="rpane-toolbar comments-toolbar" hidden>
+              <input type="text" id="comments-filter" class="filter-input" placeholder="搜索内容 / 用户..." />
+              <span class="muted">共 <span id="comments-total-count">0</span> 条</span>
+            </div>
+            <table class="table comments-table" hidden>
+              <thead>
+                <tr>
+                  <th class="w-idx">#</th>
+                  <th class="w-level" data-sort="level" title="1=根评论, 2=回复">层</th>
+                  <th data-sort="nickname">用户</th>
+                  <th>内容</th>
+                  <th class="num" data-sort="like_count">赞</th>
+                  <th class="w-time" data-sort="upload_time">时间</th>
+                  <th data-sort="ip_location">归属地</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <!-- right: progress + log -->
+    <aside class="right">
+      <div class="card status-card">
+        <header class="card-head">
+          <h3>进度</h3>
+          <span class="status-badge" id="dock-state">空闲</span>
+          <button id="stop-btn" class="btn-ghost xs danger" disabled>停止</button>
+        </header>
+        <div class="card-body status-body">
+          <div class="metrics">
+            <div class="metric">
+              <span class="m-key">阶段</span>
+              <span class="m-val" id="m-phase">—</span>
+            </div>
+            <div class="metric">
+              <span class="m-key">笔记</span>
+              <span class="m-val" id="m-notes">0 / 0</span>
+            </div>
+            <div class="metric">
+              <span class="m-key">评论</span>
+              <span class="m-val" id="m-comments">0</span>
+            </div>
+            <div class="metric">
+              <span class="m-key">耗时</span>
+              <span class="m-val" id="m-elapsed">0.0s</span>
+            </div>
+          </div>
+
+          <div class="bars">
+            <div class="bar">
+              <div class="bar-row"><span>总体</span><span id="bar-overall-pct" class="muted">—</span></div>
+              <div class="bar-track"><div class="bar-fill" id="bar-overall"></div></div>
+            </div>
+            <div class="bar">
+              <div class="bar-row"><span>当前</span><span id="bar-current-pct" class="muted">—</span></div>
+              <div class="bar-track"><div class="bar-fill alt" id="bar-current"></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card log-card">
+        <header class="card-head">
+          <h3>日志</h3>
+          <button class="btn-ghost xs" id="clear-feed">清空</button>
+        </header>
+        <ol class="feed" id="feed"></ol>
+      </div>
+    </aside>
+  </main>
+
+  <!-- 笔记预览抽屉 -->
+  <div class="drawer" id="note-drawer" hidden>
+    <div class="drawer-mask" data-close></div>
+    <aside class="drawer-panel">
+      <header class="drawer-head">
+        <h3 id="dr-title">笔记预览</h3>
+        <a id="dr-open" class="btn-ghost xs" target="_blank" rel="noopener">在小红书打开 ↗</a>
+        <button class="btn-ghost xs" data-close>关闭</button>
+      </header>
+      <div class="drawer-body" id="drawer-body">
+        <div class="empty">加载中…</div>
+      </div>
+    </aside>
+  </div>
+
+  <footer class="ftr">
+    <span>Spider_XHS · 仅供学习交流，禁止商业用途</span>
+  </footer>
+
+  <script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>

--- a/xhs_utils/data_util.py
+++ b/xhs_utils/data_util.py
@@ -143,7 +143,7 @@ def handle_note_info(data):
         'ip_location': ip_location,
     }
 
-def handle_comment_info(data):
+def handle_comment_info(data, parent_comment_id='', level=1):
     note_id = data['note_id']
     note_url = data['note_url']
     comment_id = data['id']
@@ -165,8 +165,6 @@ def handle_comment_info(data):
         for picture in pictures_temp:
             try:
                 pictures.append(picture['info_list'][1]['url'])
-                # success, msg, img_url = XHS_Apis.get_note_no_water_img(picture['info_list'][1]['url'])
-                # pictures.append(img_url)
             except (KeyError, IndexError, TypeError):
                 pass
     except (KeyError, TypeError):
@@ -175,6 +173,8 @@ def handle_comment_info(data):
         'note_id': note_id,
         'note_url': note_url,
         'comment_id': comment_id,
+        'parent_comment_id': parent_comment_id,
+        'level': level,
         'user_id': user_id,
         'home_url': home_url,
         'nickname': nickname,
@@ -194,16 +194,30 @@ def save_to_xlsx(datas, file_path, type='note'):
     elif type == 'user':
         headers = ['用户id', '用户主页url', '用户名', '头像url', '小红书号', '性别', 'ip地址', '介绍', '关注数量', '粉丝数量', '作品被赞和收藏数量', '标签']
     else:
-        headers = ['笔记id', '笔记url', '评论id', '用户id', '用户主页url', '昵称', '头像url', '评论内容', '评论标签', '点赞数量', '上传时间', 'ip归属地', '图片地址url列表']
+        headers = ['笔记id', '笔记url', '评论id', '父评论id', '层级', '用户id', '用户主页url', '昵称', '头像url', '评论内容', '评论标签', '点赞数量', '上传时间', 'ip归属地', '图片地址url列表']
     field_keys = {
         'note': ['note_id', 'note_url', 'note_type', 'user_id', 'home_url', 'nickname', 'avatar', 'title', 'desc', 'liked_count', 'collected_count', 'comment_count', 'share_count', 'video_cover', 'video_addr', 'image_list', 'tags', 'upload_time', 'ip_location'],
         'user': ['user_id', 'home_url', 'nickname', 'avatar', 'red_id', 'gender', 'ip_location', 'desc', 'follows', 'fans', 'interaction', 'tags'],
-        'comment': ['note_id', 'note_url', 'comment_id', 'user_id', 'home_url', 'nickname', 'avatar', 'content', 'show_tags', 'like_count', 'upload_time', 'ip_location', 'pictures'],
+        'comment': ['note_id', 'note_url', 'comment_id', 'parent_comment_id', 'level', 'user_id', 'home_url', 'nickname', 'avatar', 'content', 'show_tags', 'like_count', 'upload_time', 'ip_location', 'pictures'],
     }
     keys = field_keys.get(type, field_keys['comment'])
     ws.append(headers)
+    # 评论按 (parent_comment_id, level, comment_id) 排序，让根评论与其子评论紧挨着输出
+    if type == 'comment':
+        def _sort_key(d):
+            level = d.get('level', 1) or 1
+            if level == 1:
+                return (str(d.get('comment_id', '')), 0, '')
+            return (str(d.get('parent_comment_id', '')), 1, str(d.get('comment_id', '')))
+        datas = sorted(datas, key=_sort_key)
     for data in datas:
-        ws.append([norm_text(str(data.get(key, ''))) for key in keys])
+        row = []
+        for key in keys:
+            v = data.get(key, '')
+            if isinstance(v, list):
+                v = ';'.join(str(x) for x in v if x not in (None, ''))
+            row.append(norm_text(str(v)))
+        ws.append(row)
     wb.save(file_path)
     logger.info(f'数据保存至 {file_path}')
 


### PR DESCRIPTION
## Summary

- 新增 Flask Web 后端 + 单页前端，让小红书数据采集脱离命令行：评论 / 主页 / 关键词搜索三种 kind 可视化操作，实时进度（SSE）+ 历史任务管理
- 任务持久化到 `data/tasks/<id>/`，重启服务后历史不丢；同一任务可多次「追加运行」
- 新建 `/` 工具集首页，目前仅 XHS 一项；后续接入抖音 / 微博等平台只需在 `server.py` 的 `TOOLS` 列表追加配置
- 改良 xlsx 导出：评论新增「父评论 id / 层级」两列、按根+子紧邻排序，列表字段（image_list / tags / pictures）用 `;` 拼接，便于二次处理

## 主要文件

- `server.py` — Flask 后端：Task 模型 + 持久化 + SSE 流 + 图片代理 + 笔记预览聚合
- `web/templates/home.html` — 工具集首页
- `web/templates/index.html` — 小红书工具页（4 个 tab：评论 / 主页 / 关键词 / 历史）
- `web/static/styles.css` / `app.js` / `home.css` — 前端逻辑与样式
- `xhs_utils/data_util.py` — `handle_comment_info(parent_comment_id, level)` + `save_to_xlsx` list join + 评论排序
- `comment_gui.py` — 早期 tkinter 版本（保留作为命令行场景的轻量入口）
- `requirements.txt` — 加入 `flask`
- `.gitignore` — 忽略 `data/` `datas/` 运行时数据目录

## 启动

```bash
pip install -r requirements.txt
python server.py            # 默认 127.0.0.1:5000
```

打开 <http://127.0.0.1:5000> → 选择「小红书采集工具」进入。Cookie 优先从浏览器 localStorage 读取，未配置时回退 `.env` 的 `COOKIES`。

## 主要能力

| 模块 | 能力 |
|---|---|
| 评论采集 | 多 URL 粘贴，分页拉取一级 / 二级评论 |
| 主页采集 | 用户主页 URL → 全部已发布笔记，可选连带采评论 |
| 关键词搜索 | 关键词 + 数量 / 排序 / 类型 / 时间过滤 |
| 笔记表格 | 多选、筛选、排序（点赞 / 收藏 / 评论 / 时间）、预览抽屉、原文跳转 |
| 评论表格 | 多列排序、内容/用户筛选、根+子紧邻显示、`回复` 标签 |
| 批量动作 | 「采集评论」按选中 URL 走，「补全详情」可只补选中且未补的 |
| 历史任务 | 列出所有任务，载入后可继续追加搜索 / 主页 / 评论 / 详情 |
| 笔记预览 | 抽屉展示元信息 / 描述 / 图集（grid）/ 视频 / 标签 + 该笔记的评论（root + 嵌套子评论） |
| 图片显示 | 后端 `/api/img` 加 Referer 代理 XHS CDN，避开防盗链 |
| 导出 | xlsx，列表用 `;` 拼接，评论按父子关系紧邻排序 |

## Test plan

- [ ] `pip install -r requirements.txt` 后 `python server.py` 启动无报错
- [ ] 浏览器打开 `/` 看到工具集首页，点卡片进入 `/xhs`
- [ ] 配置有效 Cookie 后能跑通三种采集（评论 / 主页 / 关键词）
- [ ] 笔记列表的列头排序、筛选、勾选 + 全选切换都正常
- [ ] 「采集评论」「补全详情」按选中工作；中断后再点能补未完成的
- [ ] 预览抽屉展示完整图集/视频，评论按 root + 子嵌套
- [ ] 导出的 `comments_<tid>.xlsx` 含「父评论id / 层级」两列；`tags / image_list` 等字段为 `a;b;c` 格式
- [ ] 重启服务后「历史任务」tab 能看到之前跑过的任务，可载入继续追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)