### PR TITLE
feat: keyword-to-users pipeline with anti-crawl measures and LLM filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 node_modules/
+.env
+datas/
 *.so
 .Python
 build/

--- a/apis/xhs_pc_apis.py
+++ b/apis/xhs_pc_apis.py
@@ -129,7 +129,8 @@ class XHS_Apis():
                 "target_user_id": user_id
             }
             splice_api = splice_str(api, params)
-            headers, cookies, data = generate_request_params(cookies_str, splice_api, '', 'GET')
+            referer = f"https://www.xiaohongshu.com/user/profile/{user_id}"
+            headers, cookies, data = generate_request_params(cookies_str, splice_api, '', 'GET', referer=referer)
             response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies, timeout=REQUEST_TIMEOUT)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
@@ -646,7 +647,8 @@ class XHS_Apis():
                 "xsec_token": xsec_token
             }
             splice_api = splice_str(api, params)
-            headers, cookies, data = generate_request_params(cookies_str, splice_api, '', 'GET')
+            referer = f"https://www.xiaohongshu.com/explore/{note_id}"
+            headers, cookies, data = generate_request_params(cookies_str, splice_api, '', 'GET', referer=referer)
             response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies, timeout=REQUEST_TIMEOUT)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]
@@ -703,7 +705,8 @@ class XHS_Apis():
                 "xsec_token": xsec_token
             }
             splice_api = splice_str(api, params)
-            headers, cookies, data = generate_request_params(cookies_str, splice_api, '', 'GET')
+            referer = f"https://www.xiaohongshu.com/explore/{comment['note_id']}"
+            headers, cookies, data = generate_request_params(cookies_str, splice_api, '', 'GET', referer=referer)
             response = requests.get(self.base_url + splice_api, headers=headers, cookies=cookies, proxies=proxies, timeout=REQUEST_TIMEOUT)
             res_json = response.json()
             success, msg = res_json["success"], res_json["msg"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+PYTHONPATH="$(pwd)" .venv/bin/python spider/spider.py "$@"

--- a/spider/spider.py
+++ b/spider/spider.py
@@ -1,14 +1,53 @@
 import json
 import os
+import random
+import time
 from loguru import logger
 from apis.xhs_pc_apis import XHS_Apis
 from xhs_utils.common_util import init
-from xhs_utils.data_util import handle_note_info, download_note, save_to_xlsx
+from xhs_utils.data_util import (
+    handle_note_info, handle_user_info, handle_comment_info,
+    download_note, save_to_xlsx,
+    filter_comments, filter_users, save_to_csv,
+)
+from xhs_utils.http_util import random_delay, rate_limited_delay, reset_request_counter
+from xhs_utils.llm_util import analyze_dating_tendency, is_marketing_account
+
+
+class SessionExpiredError(Exception):
+    pass
+
+
+_SESSION_EXPIRED_KEYWORDS = ('登录已过期', '登录失效', '未登录', 'login_required', 'auth_required')
+
+
+def _is_session_expired(msg: str) -> bool:
+    s = str(msg).lower()
+    return any(kw in s for kw in _SESSION_EXPIRED_KEYWORDS) or ('登录' in s and ('过期' in s or '失效' in s))
 
 
 class Data_Spider():
     def __init__(self):
         self.xhs_apis = XHS_Apis()
+        self._last_keepalive: float = time.time()
+
+    def check_session(self, cookies_str: str, proxies=None) -> None:
+        """快速探测 cookie 是否有效，无效则抛出 SessionExpiredError。"""
+        success, msg, _ = self.xhs_apis.get_homefeed_all_channel(cookies_str, proxies)
+        if not success:
+            if _is_session_expired(msg):
+                raise SessionExpiredError(f'Cookie 已失效: {msg}')
+            logger.warning(f'[Session] 探测失败（非登录问题）: {msg}')
+
+    def _maybe_keepalive(self, cookies_str: str, proxies=None, interval: float = 600.0) -> None:
+        """距上次心跳超过 interval 秒时，发一次轻量请求保持 session 活跃。"""
+        if time.time() - self._last_keepalive >= interval:
+            logger.debug('[Keepalive] 发送心跳请求')
+            try:
+                self.xhs_apis.get_homefeed_all_channel(cookies_str, proxies)
+            except Exception as e:
+                logger.warning(f'[Keepalive] 心跳请求异常: {e}')
+            self._last_keepalive = time.time()
 
     def spider_note(self, note_url: str, cookies_str: str, proxies=None):
         """
@@ -110,6 +149,200 @@ class Data_Spider():
         logger.info(f'搜索关键词 {query} 笔记: {success}, msg: {msg}')
         return note_list, success, msg
 
+    def spider_keyword_to_users(
+        self,
+        query: str,
+        cookies_str: str,
+        base_path: dict,
+        note_num: int = 100,
+        comment_filter_regions: list = None,
+        comment_filter_days: int = 7,
+        user_filter_genders: list = None,
+        user_filter_age_range: tuple = None,
+        user_filter_fans_max: int = None,
+        delay_range: tuple = (5.0, 15.0),
+        cooldown_every: int = 10,
+        cooldown_range: tuple = (60.0, 120.0),
+        proxies: dict = None,
+    ):
+        """
+        关键词搜索 → 爬评论 → 过滤用户 → 拉用户信息 → 过滤 → 保存 CSV
+
+        :param query                   搜索关键词
+        :param cookies_str             Cookie 字符串
+        :param base_path               保存路径 dict，含 excel key
+        :param note_num                爬取笔记数量，默认 100
+        :param comment_filter_regions  省份列表，如 ["北京"]，None 表示不过滤
+        :param comment_filter_days     最近 N 天，默认 7 天，None 表示不过滤
+        :param user_filter_genders     性别列表，如 ["女"]，None 表示不过滤
+        :param user_filter_age_range   年龄区间 (min, max)，如 (35, 45)，None 表示不过滤
+        :param user_filter_fans_max    粉丝数上限（不含），如 1000，None 表示不过滤
+        :param delay_range             每次请求间随机延迟范围 (min_s, max_s)，默认 5~15s
+        :param cooldown_every          每隔 N 次请求触发一次长冷却，默认 10
+        :param cooldown_range          长冷却时长范围 (min_s, max_s)，默认 60~120s
+        :param proxies                 代理配置
+        """
+        reset_request_counter()
+        all_comments = []
+        seen_user_ids = set()
+        candidate_user_ids = []
+
+        # 健康检查：pipeline 启动前确认 cookie 有效
+        logger.info('[Pipeline] 校验 Cookie 有效性...')
+        self.check_session(cookies_str, proxies)
+        self._last_keepalive = time.time()
+        logger.info('[Pipeline] Cookie 有效')
+
+        # Step 1: 按时间排序搜索笔记
+        logger.info(f'[Pipeline] 搜索关键词: {query}，数量: {note_num}')
+        success, msg, notes = self.xhs_apis.search_some_note(
+            query, note_num, cookies_str,
+            sort_type_choice=1,  # 最新
+            note_type=2,         # 只要图文，过滤视频
+            proxies=proxies,
+        )
+        if not success:
+            if _is_session_expired(msg):
+                raise SessionExpiredError(f'搜索时 Cookie 失效: {msg}')
+            logger.error(f'[Pipeline] 搜索失败: {msg}')
+            return [], [], False, msg
+
+        # 跳过零评论笔记；随机打乱访问顺序
+        def _comment_count(n: dict) -> int:
+            try:
+                return int(n.get('note_card', {}).get('interact_info', {}).get('comment_count', 0) or 0)
+            except (ValueError, TypeError):
+                return 0
+
+        valid_notes = [n for n in notes if n.get('model_type') == 'note' and _comment_count(n) > 0]
+        skipped = len([n for n in notes if n.get('model_type') == 'note']) - len(valid_notes)
+        if skipped:
+            logger.info(f'[Pipeline] 跳过零评论笔记 {skipped} 篇')
+
+        random.shuffle(valid_notes)
+
+        note_urls = [
+            f"https://www.xiaohongshu.com/explore/{n['id']}?xsec_token={n['xsec_token']}"
+            for n in valid_notes
+        ]
+        logger.info(f'[Pipeline] 有效笔记 {len(note_urls)} 篇（已打乱顺序）')
+
+        # Step 2: 逐篇爬评论
+        for note_url in note_urls:
+            self._maybe_keepalive(cookies_str, proxies)
+            rate_limited_delay(*delay_range, cooldown_every=cooldown_every, cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
+            success, msg, out_comments = self.xhs_apis.get_note_all_comment(
+                note_url, cookies_str, proxies
+            )
+            if not success:
+                if _is_session_expired(msg):
+                    raise SessionExpiredError(f'爬评论时 Cookie 失效: {msg}')
+                logger.warning(f'[Pipeline] 评论获取失败 {note_url}: {msg}')
+                continue
+
+            for comment in out_comments:
+                comment_info = handle_comment_info({**comment, 'note_url': note_url})
+                all_comments.append(comment_info)
+                # 收集二级评论
+                for sub in comment.get('sub_comments', []):
+                    sub_info = handle_comment_info({**sub, 'note_url': note_url})
+                    all_comments.append(sub_info)
+
+        logger.info(f'[Pipeline] 共获取评论 {len(all_comments)} 条')
+
+        # Step 3: 按省份 + 时间过滤评论，去重得到候选用户
+        filtered_comments = filter_comments(all_comments, comment_filter_regions, comment_filter_days)
+        logger.info(f'[Pipeline] 过滤后评论 {len(filtered_comments)} 条')
+
+        for c in filtered_comments:
+            uid = c.get('user_id')
+            if uid and uid not in seen_user_ids:
+                seen_user_ids.add(uid)
+                candidate_user_ids.append(uid)
+        logger.info(f'[Pipeline] 候选用户 {len(candidate_user_ids)} 人')
+
+        # Step 4: 拉取用户信息
+        user_list = []
+        for user_id in candidate_user_ids:
+            self._maybe_keepalive(cookies_str, proxies)
+            rate_limited_delay(*delay_range, cooldown_every=cooldown_every, cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
+            success, msg, res_json = self.xhs_apis.get_user_info(user_id, cookies_str, proxies)
+            if not success or not res_json:
+                if _is_session_expired(msg):
+                    raise SessionExpiredError(f'拉用户信息时 Cookie 失效: {msg}')
+                logger.warning(f'[Pipeline] 用户信息获取失败 {user_id}: {msg}')
+                continue
+            try:
+                user_info = handle_user_info(res_json['data'], user_id)
+                user_list.append(user_info)
+            except Exception as e:
+                logger.warning(f'[Pipeline] 用户信息解析失败 {user_id}: {e}')
+
+        logger.info(f'[Pipeline] 获取用户信息 {len(user_list)} 人')
+
+        # Step 5: 按性别 + 年龄区间 + 粉丝数过滤用户
+        final_users = filter_users(user_list, user_filter_genders, user_filter_age_range, user_filter_fans_max)
+        logger.info(f'[Pipeline] 过滤后用户 {len(final_users)} 人')
+
+        # Step 5b: LLM 过滤营销号
+        logger.info(f'[Pipeline] LLM 过滤营销号，共 {len(final_users)} 人')
+        real_users = []
+        for user in final_users:
+            result = is_marketing_account(
+                user.get('nickname', ''),
+                user.get('desc', ''),
+                user.get('tags', []),
+            )
+            if result.get('is_marketing'):
+                logger.info(f'[Pipeline] 过滤营销号 {user["nickname"]}: {result.get("reason", "")}')
+            else:
+                real_users.append(user)
+        logger.info(f'[Pipeline] 过滤后真实用户 {len(real_users)} 人（排除营销号 {len(final_users) - len(real_users)} 人）')
+        final_users = real_users
+
+        # Step 6: LLM 分析交友倾向（爬取用户笔记标题 → Ollama qwen2.5:7b）
+        logger.info(f'[Pipeline] 开始 LLM 分析，共 {len(final_users)} 人')
+        for user in final_users:
+            note_titles = []
+            try:
+                random_delay(*delay_range)
+                success, msg, res_json = self.xhs_apis.get_user_note_info(
+                    user['user_id'], '', cookies_str, proxies=proxies
+                )
+                if success and res_json:
+                    raw_notes = res_json.get('data', {}).get('notes', [])
+                    for n in raw_notes[:10]:
+                        title = (
+                            n.get('display_title')
+                            or n.get('title')
+                            or n.get('note_card', {}).get('display_title', '')
+                            or n.get('note_card', {}).get('title', '')
+                        )
+                        if title:
+                            note_titles.append(title)
+            except Exception as e:
+                logger.warning(f'[Pipeline] 获取笔记标题失败 {user["user_id"]}: {e}')
+
+            result = analyze_dating_tendency(user.get('desc', ''), note_titles)
+            user['dating_tendency'] = result.get('tendency', '未分析')
+            user['dating_reason'] = result.get('reason', '')
+            logger.info(f'[Pipeline] LLM {user["nickname"]} → {user["dating_tendency"]}')
+
+        # Step 7: 保存 CSV
+        import os
+        from datetime import datetime
+        ts = datetime.now().strftime('%Y%m%d_%H%M%S')
+        safe_query = query.replace('/', '_').replace('\\', '_')[:20]
+
+        comment_csv = os.path.join(base_path['excel'], f'{safe_query}_评论_{ts}.csv')
+        user_csv = os.path.join(base_path['excel'], f'{safe_query}_用户_{ts}.csv')
+
+        save_to_csv(filtered_comments, comment_csv, type='comment')
+        save_to_csv(final_users, user_csv, type='user')
+
+        return filtered_comments, final_users, True, 'ok'
+
+
 if __name__ == '__main__':
     """
         此文件为爬虫的入口文件，可以直接运行
@@ -126,27 +359,21 @@ if __name__ == '__main__':
     """
 
 
-    # 1 爬取列表的所有笔记信息 笔记链接 如下所示 注意此url会过期！
-    notes = [
-        r'https://www.xiaohongshu.com/explore/683fe17f0000000023017c6a?xsec_token=ABBr_cMzallQeLyKSRdPk9fwzA0torkbT_ubuQP1ayvKA=&xsec_source=pc_user',
-    ]
-    data_spider.spider_some_note(notes, cookies_str, base_path, 'all', 'test')
-
-    # 2 爬取用户的所有笔记信息 用户链接 如下所示 注意此url会过期！
-    user_url = 'https://www.xiaohongshu.com/user/profile/64c3f392000000002b009e45?xsec_token=AB-GhAToFu07JwNk_AMICHnp7bSTjVz2beVIDBwSyPwvM=&xsec_source=pc_feed'
-    data_spider.spider_user_all_note(user_url, cookies_str, base_path, 'all')
-
-    # 3 搜索指定关键词的笔记
-    query = "榴莲"
-    query_num = 10
-    sort_type_choice = 0  # 0 综合排序, 1 最新, 2 最多点赞, 3 最多评论, 4 最多收藏
-    note_type = 0 # 0 不限, 1 视频笔记, 2 普通笔记
-    note_time = 0  # 0 不限, 1 一天内, 2 一周内天, 3 半年内
-    note_range = 0  # 0 不限, 1 已看过, 2 未看过, 3 已关注
-    pos_distance = 0  # 0 不限, 1 同城, 2 附近 指定这个1或2必须要指定 geo
-    # geo = {
-    #     # 经纬度
-    #     "latitude": 39.9725,
-    #     "longitude": 116.4207
-    # }
-    data_spider.spider_some_search_note(query, query_num, cookies_str, base_path, 'all', sort_type_choice, note_type, note_time, note_range, pos_distance, geo=None)
+    # 4 关键词搜索 → 评论 → 过滤用户 → 保存 CSV
+    try:
+        data_spider.spider_keyword_to_users(
+            query="读书搭子",
+            cookies_str=cookies_str,
+            base_path=base_path,
+            note_num=100,                    # 拉最新 100 篇笔记
+            comment_filter_regions=["北京"], # 只保留北京 IP 的评论
+            comment_filter_days=7,           # 最近一周
+            user_filter_genders=["女"],      # 只保留女性
+            user_filter_age_range=(35, 45),  # 年龄 35-45 岁
+            user_filter_fans_max=1000,       # 粉丝数 < 1000
+            delay_range=(5.0, 15.0),      # 每次请求随机等待 5~15s
+            cooldown_every=10,            # 每 10 次触发冷却
+            cooldown_range=(60.0, 120.0), # 冷却 60~120s
+        )
+    except SessionExpiredError as e:
+        logger.error(f'[Pipeline] Cookie 已失效，请重新获取 Cookie 后重试。详情: {e}')

--- a/spider/spider.py
+++ b/spider/spider.py
@@ -2,6 +2,7 @@ import json
 import os
 import random
 import time
+from datetime import datetime
 from loguru import logger
 from apis.xhs_pc_apis import XHS_Apis
 from xhs_utils.common_util import init
@@ -183,9 +184,9 @@ class Data_Spider():
         :param proxies                 代理配置
         """
         reset_request_counter()
-        all_comments = []
-        seen_user_ids = set()
-        candidate_user_ids = []
+        all_filtered_comments = []
+        all_final_users = []
+        seen_user_ids: set = set()
 
         # 健康检查：pipeline 启动前确认 cookie 有效
         logger.info('[Pipeline] 校验 Cookie 有效性...')
@@ -207,140 +208,113 @@ class Data_Spider():
             logger.error(f'[Pipeline] 搜索失败: {msg}')
             return [], [], False, msg
 
-        # 跳过零评论笔记；随机打乱访问顺序
-        def _comment_count(n: dict) -> int:
+        def _note_comment_count(n: dict) -> int:
             try:
                 return int(n.get('note_card', {}).get('interact_info', {}).get('comment_count', 0) or 0)
             except (ValueError, TypeError):
                 return 0
 
-        valid_notes = [n for n in notes if n.get('model_type') == 'note' and _comment_count(n) > 0]
+        valid_notes = [n for n in notes if n.get('model_type') == 'note' and _note_comment_count(n) > 0]
         skipped = len([n for n in notes if n.get('model_type') == 'note']) - len(valid_notes)
         if skipped:
             logger.info(f'[Pipeline] 跳过零评论笔记 {skipped} 篇')
-
         random.shuffle(valid_notes)
+        logger.info(f'[Pipeline] 有效笔记 {len(valid_notes)} 篇（已打乱顺序），开始深度优先处理')
 
-        note_urls = [
-            f"https://www.xiaohongshu.com/explore/{n['id']}?xsec_token={n['xsec_token']}"
-            for n in valid_notes
-        ]
-        logger.info(f'[Pipeline] 有效笔记 {len(note_urls)} 篇（已打乱顺序）')
+        # 深度优先：每篇笔记独立走完 评论→过滤→用户→LLM 全流程
+        for note in valid_notes:
+            note_url = f"https://www.xiaohongshu.com/explore/{note['id']}?xsec_token={note['xsec_token']}"
 
-        # Step 2: 逐篇爬评论
-        for note_url in note_urls:
+            # Step 2: 拉取本篇笔记评论
             self._maybe_keepalive(cookies_str, proxies)
-            rate_limited_delay(*delay_range, cooldown_every=cooldown_every, cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
-            success, msg, out_comments = self.xhs_apis.get_note_all_comment(
-                note_url, cookies_str, proxies
-            )
+            rate_limited_delay(*delay_range, cooldown_every=cooldown_every,
+                               cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
+            success, msg, out_comments = self.xhs_apis.get_note_all_comment(note_url, cookies_str, proxies)
             if not success:
                 if _is_session_expired(msg):
                     raise SessionExpiredError(f'爬评论时 Cookie 失效: {msg}')
                 logger.warning(f'[Pipeline] 评论获取失败 {note_url}: {msg}')
                 continue
 
+            note_comments = []
             for comment in out_comments:
-                comment_info = handle_comment_info({**comment, 'note_url': note_url})
-                all_comments.append(comment_info)
-                # 收集二级评论
+                note_comments.append(handle_comment_info({**comment, 'note_url': note_url}))
                 for sub in comment.get('sub_comments', []):
-                    sub_info = handle_comment_info({**sub, 'note_url': note_url})
-                    all_comments.append(sub_info)
+                    note_comments.append(handle_comment_info({**sub, 'note_url': note_url}))
 
-        logger.info(f'[Pipeline] 共获取评论 {len(all_comments)} 条')
+            # Step 3: 按省份 + 时间过滤本篇评论
+            filtered = filter_comments(note_comments, comment_filter_regions, comment_filter_days)
+            all_filtered_comments.extend(filtered)
 
-        # Step 3: 按省份 + 时间过滤评论，去重得到候选用户
-        filtered_comments = filter_comments(all_comments, comment_filter_regions, comment_filter_days)
-        logger.info(f'[Pipeline] 过滤后评论 {len(filtered_comments)} 条')
-
-        for c in filtered_comments:
-            uid = c.get('user_id')
-            if uid and uid not in seen_user_ids:
+            # Steps 4-6: 对本篇新出现的候选用户逐一完成全流程
+            for c in filtered:
+                uid = c.get('user_id')
+                if not uid or uid in seen_user_ids:
+                    continue
                 seen_user_ids.add(uid)
-                candidate_user_ids.append(uid)
-        logger.info(f'[Pipeline] 候选用户 {len(candidate_user_ids)} 人')
 
-        # Step 4: 拉取用户信息
-        user_list = []
-        for user_id in candidate_user_ids:
-            self._maybe_keepalive(cookies_str, proxies)
-            rate_limited_delay(*delay_range, cooldown_every=cooldown_every, cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
-            success, msg, res_json = self.xhs_apis.get_user_info(user_id, cookies_str, proxies)
-            if not success or not res_json:
-                if _is_session_expired(msg):
-                    raise SessionExpiredError(f'拉用户信息时 Cookie 失效: {msg}')
-                logger.warning(f'[Pipeline] 用户信息获取失败 {user_id}: {msg}')
-                continue
-            try:
-                user_info = handle_user_info(res_json['data'], user_id)
-                user_list.append(user_info)
-            except Exception as e:
-                logger.warning(f'[Pipeline] 用户信息解析失败 {user_id}: {e}')
+                # Step 4: 拉取用户信息
+                self._maybe_keepalive(cookies_str, proxies)
+                rate_limited_delay(*delay_range, cooldown_every=cooldown_every,
+                                   cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
+                success, msg, res_json = self.xhs_apis.get_user_info(uid, cookies_str, proxies)
+                if not success or not res_json:
+                    if _is_session_expired(msg):
+                        raise SessionExpiredError(f'拉用户信息时 Cookie 失效: {msg}')
+                    logger.warning(f'[Pipeline] 用户信息获取失败 {uid}: {msg}')
+                    continue
+                try:
+                    user_info = handle_user_info(res_json['data'], uid)
+                except Exception as e:
+                    logger.warning(f'[Pipeline] 用户信息解析失败 {uid}: {e}')
+                    continue
 
-        logger.info(f'[Pipeline] 获取用户信息 {len(user_list)} 人')
+                # Step 5: 人口属性过滤（性别 / 年龄 / 粉丝数）
+                if not filter_users([user_info], user_filter_genders, user_filter_age_range, user_filter_fans_max):
+                    continue
 
-        # Step 5: 按性别 + 年龄区间 + 粉丝数过滤用户
-        final_users = filter_users(user_list, user_filter_genders, user_filter_age_range, user_filter_fans_max)
-        logger.info(f'[Pipeline] 过滤后用户 {len(final_users)} 人')
+                # Step 5b: LLM 过滤营销号
+                mkt = is_marketing_account(user_info.get('nickname', ''), user_info.get('desc', ''), user_info.get('tags', []))
+                if mkt.get('is_marketing'):
+                    logger.info(f'[Pipeline] 过滤营销号 {user_info["nickname"]}: {mkt.get("reason", "")}')
+                    continue
 
-        # Step 5b: LLM 过滤营销号
-        logger.info(f'[Pipeline] LLM 过滤营销号，共 {len(final_users)} 人')
-        real_users = []
-        for user in final_users:
-            result = is_marketing_account(
-                user.get('nickname', ''),
-                user.get('desc', ''),
-                user.get('tags', []),
-            )
-            if result.get('is_marketing'):
-                logger.info(f'[Pipeline] 过滤营销号 {user["nickname"]}: {result.get("reason", "")}')
-            else:
-                real_users.append(user)
-        logger.info(f'[Pipeline] 过滤后真实用户 {len(real_users)} 人（排除营销号 {len(final_users) - len(real_users)} 人）')
-        final_users = real_users
+                # Step 6: 拉取用户笔记标题 → LLM 分析交友倾向
+                note_titles = []
+                try:
+                    self._maybe_keepalive(cookies_str, proxies)
+                    rate_limited_delay(*delay_range, cooldown_every=cooldown_every,
+                                       cooldown_min=cooldown_range[0], cooldown_max=cooldown_range[1])
+                    success, msg, nres = self.xhs_apis.get_user_note_info(uid, '', cookies_str, proxies=proxies)
+                    if success and nres:
+                        for n in nres.get('data', {}).get('notes', [])[:10]:
+                            title = (
+                                n.get('display_title') or n.get('title')
+                                or n.get('note_card', {}).get('display_title', '')
+                                or n.get('note_card', {}).get('title', '')
+                            )
+                            if title:
+                                note_titles.append(title)
+                except Exception as e:
+                    logger.warning(f'[Pipeline] 获取笔记标题失败 {uid}: {e}')
 
-        # Step 6: LLM 分析交友倾向（爬取用户笔记标题 → Ollama qwen2.5:7b）
-        logger.info(f'[Pipeline] 开始 LLM 分析，共 {len(final_users)} 人')
-        for user in final_users:
-            note_titles = []
-            try:
-                random_delay(*delay_range)
-                success, msg, res_json = self.xhs_apis.get_user_note_info(
-                    user['user_id'], '', cookies_str, proxies=proxies
-                )
-                if success and res_json:
-                    raw_notes = res_json.get('data', {}).get('notes', [])
-                    for n in raw_notes[:10]:
-                        title = (
-                            n.get('display_title')
-                            or n.get('title')
-                            or n.get('note_card', {}).get('display_title', '')
-                            or n.get('note_card', {}).get('title', '')
-                        )
-                        if title:
-                            note_titles.append(title)
-            except Exception as e:
-                logger.warning(f'[Pipeline] 获取笔记标题失败 {user["user_id"]}: {e}')
+                tendency = analyze_dating_tendency(user_info.get('desc', ''), note_titles)
+                user_info['dating_tendency'] = tendency.get('tendency', '未分析')
+                user_info['dating_reason'] = tendency.get('reason', '')
+                all_final_users.append(user_info)
+                logger.info(f'[Pipeline] 新增用户 {user_info["nickname"]} → {user_info["dating_tendency"]}')
 
-            result = analyze_dating_tendency(user.get('desc', ''), note_titles)
-            user['dating_tendency'] = result.get('tendency', '未分析')
-            user['dating_reason'] = result.get('reason', '')
-            logger.info(f'[Pipeline] LLM {user["nickname"]} → {user["dating_tendency"]}')
+        logger.info(f'[Pipeline] 完成。过滤评论 {len(all_filtered_comments)} 条，最终用户 {len(all_final_users)} 人')
 
         # Step 7: 保存 CSV
-        import os
-        from datetime import datetime
         ts = datetime.now().strftime('%Y%m%d_%H%M%S')
         safe_query = query.replace('/', '_').replace('\\', '_')[:20]
-
         comment_csv = os.path.join(base_path['excel'], f'{safe_query}_评论_{ts}.csv')
         user_csv = os.path.join(base_path['excel'], f'{safe_query}_用户_{ts}.csv')
+        save_to_csv(all_filtered_comments, comment_csv, type='comment')
+        save_to_csv(all_final_users, user_csv, type='user')
 
-        save_to_csv(filtered_comments, comment_csv, type='comment')
-        save_to_csv(final_users, user_csv, type='user')
-
-        return filtered_comments, final_users, True, 'ok'
+        return all_filtered_comments, all_final_users, True, 'ok'
 
 
 if __name__ == '__main__':

--- a/test_phase1.py
+++ b/test_phase1.py
@@ -1,0 +1,81 @@
+"""Phase 1 cookie validation: minimum-request smoke test for Spider_XHS APIs.
+
+Total HTTP requests issued: 3 (search note, search user, user info).
+Inserts sleeps between calls to look less bot-like.
+"""
+
+from __future__ import annotations
+
+import os
+
+import sys
+import time
+
+from loguru import logger
+
+from apis.xhs_pc_apis import XHS_Apis
+from xhs_utils.common_util import load_env
+
+QUERY = "榴莲"
+SLEEP_SECONDS = 4
+
+
+def _truncate(value: object, limit: int = 200) -> str:
+    text = str(value)
+    return text if len(text) <= limit else text[:limit] + "...(truncated)"
+
+
+def main() -> int:
+    cookies_str = load_env()
+    if not cookies_str:
+        logger.error("COOKIES env var is empty — aborting")
+        return 1
+
+    apis = XHS_Apis()
+
+    logger.info(f"[1/3] search_some_note(query={QUERY!r}, require_num=1)")
+    success, msg, notes = apis.search_some_note(QUERY, 1, cookies_str)
+    if not success or not notes:
+        logger.error(f"search_some_note failed: success={success} msg={_truncate(msg)}")
+        return 2
+    first = notes[0]
+    logger.info(f"note hit: id={first.get('id')} model_type={first.get('model_type')} keys={list(first.keys())[:8]}")
+
+    time.sleep(SLEEP_SECONDS)
+
+    logger.info(f"[2/3] search_some_user(query={QUERY!r}, require_num=1)")
+    success, msg, users = apis.search_some_user(QUERY, 1, cookies_str)
+    if not success or not users:
+        logger.error(f"search_some_user failed: success={success} msg={_truncate(msg)}")
+        return 3
+    user = users[0]
+    user_id = user.get("id") or user.get("user_id") or user.get("userid")
+    logger.info(
+        f"user hit: id={user_id} name={user.get('name') or user.get('nickname')} keys={list(user.keys())[:10]}"
+    )
+    if not user_id:
+        logger.error(f"could not locate user id in search result; raw={_truncate(user)}")
+        return 4
+
+    time.sleep(SLEEP_SECONDS)
+
+    logger.info(f"[3/3] get_user_info(user_id={user_id})")
+    success, msg, info = apis.get_user_info(user_id, cookies_str)
+    if not success:
+        logger.error(f"get_user_info failed: success={success} msg={_truncate(msg)}")
+        return 5
+    data = (info or {}).get("data") or {}
+    basic = data.get("basic_info") or data.get("basicInfo") or {}
+    interactions = data.get("interactions") or []
+    logger.info(
+        f"user_info ok: nickname={basic.get('nickname')} ip={basic.get('ip_location')} "
+        f"gender={basic.get('gender')} desc={_truncate(basic.get('desc'), 80)}"
+    )
+    logger.info(f"interactions: {_truncate(interactions, 200)}")
+
+    logger.success("Phase 1 smoke test passed — Cookie is alive on all three endpoints.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xhs_utils/data_util.py
+++ b/xhs_utils/data_util.py
@@ -1,7 +1,9 @@
+import csv
 import json
 import os
 import re
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import openpyxl
@@ -10,6 +12,19 @@ from loguru import logger
 from retry import retry
 
 from xhs_utils.http_util import REQUEST_TIMEOUT
+
+_AGE_TAG_PATTERNS = ["60后", "65后", "70后", "75后", "80后", "85后", "90后", "95后", "00后", "05后", "10后"]
+_AGE_DESC_RE = re.compile(r'(\d{1,2})\s*岁')
+
+# 年代标签 → 出生年份区间（左闭右闭）
+_GENERATION_BIRTH_YEAR: dict[str, tuple[int, int]] = {
+    "60后": (1960, 1969), "65后": (1965, 1974),
+    "70后": (1970, 1979), "75后": (1975, 1984),
+    "80后": (1980, 1989), "85后": (1985, 1994),
+    "90后": (1990, 1999), "95后": (1995, 2004),
+    "00后": (2000, 2009), "05后": (2005, 2014),
+    "10后": (2010, 2019),
+}
 
 
 def norm_str(value):
@@ -51,7 +66,7 @@ def handle_user_info(data, user_id):
             tags.append(tag['name'])
         except (KeyError, TypeError):
             pass
-    return {
+    user = {
         'user_id': user_id,
         'home_url': home_url,
         'nickname': nickname,
@@ -65,6 +80,8 @@ def handle_user_info(data, user_id):
         'interaction': interaction,
         'tags': tags,
     }
+    user['age_info'] = extract_age_info(user)
+    return user
 
 def handle_note_info(data):
     note_id = data['id']
@@ -206,6 +223,108 @@ def save_to_xlsx(datas, file_path, type='note'):
         ws.append([norm_text(str(data.get(key, ''))) for key in keys])
     wb.save(file_path)
     logger.info(f'数据保存至 {file_path}')
+
+_CSV_FIELDS = {
+    'comment': {
+        'headers': ['发布时间', '用户主页url', 'ip归属地'],
+        'keys': ['upload_time', 'home_url', 'ip_location'],
+    },
+    'user': {
+        'headers': ['用户id', '用户主页url', '昵称', '小红书号', '性别', '年龄信息', 'ip归属地', '介绍', '关注数量', '粉丝数量', '获赞收藏数', '标签', '交友倾向', '判断理由'],
+        'keys': ['user_id', 'home_url', 'nickname', 'red_id', 'gender', 'age_info', 'ip_location', 'desc', 'follows', 'fans', 'interaction', 'tags', 'dating_tendency', 'dating_reason'],
+    },
+}
+
+
+def save_to_csv(datas: list, file_path: str, type: str = 'user') -> None:
+    fields = _CSV_FIELDS.get(type, _CSV_FIELDS['user'])
+    Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, 'w', newline='', encoding='utf-8-sig') as f:
+        writer = csv.DictWriter(f, fieldnames=fields['headers'])
+        writer.writeheader()
+        for data in datas:
+            row = {
+                header: norm_text(str(data.get(key, '')))
+                for header, key in zip(fields['headers'], fields['keys'])
+            }
+            writer.writerow(row)
+    logger.info(f'数据保存至 {file_path}')
+
+
+def extract_age_info(user: dict) -> str:
+    for tag in (user.get('tags') or []):
+        tag_str = str(tag)
+        for pattern in _AGE_TAG_PATTERNS:
+            if pattern in tag_str:
+                return pattern
+    desc = user.get('desc') or ''
+    match = _AGE_DESC_RE.search(desc)
+    if match:
+        return f"{match.group(1)}岁"
+    return '未知'
+
+
+def filter_comments(
+    comments: list,
+    regions: list[str] | None = None,
+    days: int | None = None,
+) -> list:
+    now = datetime.now()
+    result = []
+    for c in comments:
+        if regions:
+            ip_loc = c.get('ip_location') or ''
+            if not any(ip_loc.startswith(r) or r in ip_loc for r in regions):
+                continue
+        if days is not None:
+            try:
+                comment_time = datetime.strptime(c['upload_time'], '%Y-%m-%d %H:%M:%S')
+                if now - comment_time > timedelta(days=days):
+                    continue
+            except (KeyError, ValueError):
+                pass
+        result.append(c)
+    return result
+
+
+def _age_in_range(age_info: str, min_age: int, max_age: int) -> bool:
+    """判断 age_info（'X岁' 或 '90后' 等）是否落在 [min_age, max_age] 内。"""
+    m = _AGE_DESC_RE.match(age_info)
+    if m:
+        return min_age <= int(m.group(1)) <= max_age
+    current_year = datetime.now().year
+    for tag, (birth_start, birth_end) in _GENERATION_BIRTH_YEAR.items():
+        if tag in age_info:
+            # 年代标签对应的年龄区间（当前年份估算）
+            age_min = current_year - birth_end
+            age_max = current_year - birth_start
+            return age_min <= max_age and age_max >= min_age
+    return False
+
+
+def filter_users(
+    users: list,
+    genders: list[str] | None = None,
+    age_range: tuple[int, int] | None = None,
+    fans_max: int | None = None,
+) -> list:
+    result = []
+    for u in users:
+        if genders and u.get('gender') not in genders:
+            continue
+        if age_range is not None:
+            age_info = u.get('age_info', '未知')
+            if age_info == '未知' or not _age_in_range(age_info, *age_range):
+                continue
+        if fans_max is not None:
+            try:
+                if int(u.get('fans', 0)) >= fans_max:
+                    continue
+            except (ValueError, TypeError):
+                pass
+        result.append(u)
+    return result
+
 
 def download_media(path, name, url, type):
     if not url:

--- a/xhs_utils/http_util.py
+++ b/xhs_utils/http_util.py
@@ -1,1 +1,68 @@
+import random
+import threading
+import time
+
+from loguru import logger
+
 REQUEST_TIMEOUT = 15
+
+_USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.0.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 11.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+]
+
+_request_counter = 0
+_counter_lock = threading.Lock()
+
+
+def random_delay(min_seconds: float = 2.0, max_seconds: float = 5.0) -> None:
+    time.sleep(random.uniform(min_seconds, max_seconds))
+
+
+def rate_limited_delay(
+    min_seconds: float = 5.0,
+    max_seconds: float = 15.0,
+    cooldown_every: int = 10,
+    cooldown_min: float = 60.0,
+    cooldown_max: float = 120.0,
+) -> None:
+    """
+    带周期性冷却的请求限速。
+    每发送 cooldown_every 次请求后暂停 cooldown_min~cooldown_max 秒，
+    其余请求之间随机等待 min_seconds~max_seconds 秒。
+    """
+    global _request_counter
+    with _counter_lock:
+        _request_counter += 1
+        count = _request_counter
+
+    if count % cooldown_every == 0:
+        delay = random.uniform(cooldown_min, cooldown_max)
+        logger.info(f'[限速] 已发送 {count} 次请求，触发冷却 {delay:.0f}s')
+        time.sleep(delay)
+    else:
+        # 以 15% 概率插入一次较长停顿，模拟用户阅读
+        if random.random() < 0.15:
+            delay = random.uniform(max_seconds, max_seconds * 2.5)
+            logger.debug(f'[限速] 随机长停顿 {delay:.0f}s')
+            time.sleep(delay)
+        else:
+            time.sleep(random.uniform(min_seconds, max_seconds))
+
+
+def reset_request_counter() -> None:
+    global _request_counter
+    with _counter_lock:
+        _request_counter = 0
+
+
+def get_random_user_agent() -> str:
+    return random.choice(_USER_AGENTS)

--- a/xhs_utils/llm_util.py
+++ b/xhs_utils/llm_util.py
@@ -1,0 +1,119 @@
+import json
+import re
+
+from loguru import logger
+
+_MODEL = 'qwen2.5:7b'
+
+_SYSTEM_PROMPT = """你是一个分析小红书用户内容的助手。
+根据用户的个人简介和笔记标题列表，判断该用户是否有交友/约会意愿。
+
+请只输出以下 JSON 格式，不要输出其他任何内容：
+{"tendency": "有", "reason": "一句话说明"}
+
+tendency 只能取以下三个值之一：
+- 有：简介或笔记中出现找朋友、交友、脱单、相亲、单身想认识人、寻缘、约见等明确社交/情感信号
+- 无：内容以分享生活/知识/好物为主，无情感社交信号
+- 不确定：信号模糊、内容太少或无法判断"""
+
+
+def _extract_json(text: str) -> dict:
+    match = re.search(r'\{[^{}]+\}', text, re.DOTALL)
+    if match:
+        return json.loads(match.group())
+    raise ValueError(f'响应中未找到 JSON: {text[:200]}')
+
+
+_MARKETING_PROMPT = """你是一个小红书账号真实性分析助手。
+根据用户昵称、简介和标签，判断该账号是否为营销号、广告号或商业推广账号。
+
+营销号的典型特征（满足其一即可）：
+- 昵称或简介含有：微信/vx/wx/威/薇、代购、招募、商务合作、推广、接单、店铺、官方、加我、引流
+- 简介像广告文案，大量使用感叹号或促销话术
+- 整体内容以产品销售、引流变现为核心目的
+
+请只输出以下 JSON 格式，不要输出任何其他内容：
+{"is_marketing": true或false, "reason": "一句话理由"}"""
+
+
+def is_marketing_account(nickname: str, desc: str, tags: list[str]) -> dict:
+    """
+    判断用户是否为营销号。
+
+    :param nickname  用户昵称
+    :param desc      个人简介
+    :param tags      标签列表
+    :return {"is_marketing": bool, "reason": str}
+    """
+    try:
+        import ollama
+    except ImportError:
+        logger.error('ollama 包未安装，请执行: pip install ollama')
+        return {'is_marketing': False, 'reason': 'ollama 包未安装'}
+
+    tags_str = '、'.join(str(t) for t in (tags or [])[:10]) or '无'
+    user_message = (
+        f"昵称：{nickname.strip() or '（无）'}\n"
+        f"简介：{(desc or '').strip() or '（未填写）'}\n"
+        f"标签：{tags_str}"
+    )
+
+    try:
+        resp = ollama.chat(
+            model=_MODEL,
+            messages=[
+                {'role': 'system', 'content': _MARKETING_PROMPT},
+                {'role': 'user', 'content': user_message},
+            ],
+            options={'temperature': 0.0},
+        )
+        content = resp['message']['content'].strip()
+        return _extract_json(content)
+    except json.JSONDecodeError as e:
+        logger.warning(f'营销号判断 JSON 解析失败: {e}')
+        return {'is_marketing': False, 'reason': '响应格式异常'}
+    except Exception as e:
+        logger.warning(f'营销号判断失败: {e}')
+        return {'is_marketing': False, 'reason': str(e)[:120]}
+
+
+def analyze_dating_tendency(user_desc: str, note_titles: list[str]) -> dict:
+    """
+    分析用户交友倾向。
+
+    :param user_desc    用户个人简介
+    :param note_titles  用户笔记标题列表（最多取前 10 条）
+    :return {"tendency": "有/无/不确定", "reason": "..."}
+    """
+    try:
+        import ollama
+    except ImportError:
+        logger.error('ollama 包未安装，请执行: pip install ollama')
+        return {'tendency': '未分析', 'reason': 'ollama 包未安装'}
+
+    titles_text = '\n'.join(f'- {t}' for t in note_titles[:10] if str(t).strip())
+    if not titles_text:
+        titles_text = '（无笔记内容）'
+
+    user_message = (
+        f"个人简介：{user_desc.strip() or '（未填写）'}\n\n"
+        f"笔记标题：\n{titles_text}"
+    )
+
+    try:
+        resp = ollama.chat(
+            model=_MODEL,
+            messages=[
+                {'role': 'system', 'content': _SYSTEM_PROMPT},
+                {'role': 'user', 'content': user_message},
+            ],
+            options={'temperature': 0.1},
+        )
+        content = resp['message']['content'].strip()
+        return _extract_json(content)
+    except json.JSONDecodeError as e:
+        logger.warning(f'LLM 响应 JSON 解析失败: {e}')
+        return {'tendency': '不确定', 'reason': '响应格式异常'}
+    except Exception as e:
+        logger.warning(f'LLM 分析失败: {e}')
+        return {'tendency': '未分析', 'reason': str(e)[:120]}

--- a/xhs_utils/xhs_util.py
+++ b/xhs_utils/xhs_util.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 
 import execjs
 from xhs_utils.cookie_util import trans_cookies
+from xhs_utils.http_util import get_random_user_agent
 
 _STATIC_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'static'))
 
@@ -105,7 +106,7 @@ def get_request_headers_template():
         "sec-fetch-dest": "empty",
         "sec-fetch-mode": "cors",
         "sec-fetch-site": "same-site",
-        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.0.0",
+        "user-agent": get_random_user_agent(),
         "x-b3-traceid": "",
         "x-mns": "unload",
         "x-s": "",
@@ -114,7 +115,7 @@ def get_request_headers_template():
         "x-xray-traceid": generate_xray_traceid()
     }
 
-def generate_headers(a1, api, data='', method='POST'):
+def generate_headers(a1, api, data='', method='POST', referer=None):
     xs, xt, xs_common = generate_xs_xs_common(a1, api, data, method)
     x_b3_traceid = generate_x_b3_traceid()
     headers = get_request_headers_template()
@@ -122,14 +123,16 @@ def generate_headers(a1, api, data='', method='POST'):
     headers['x-t'] = str(xt)
     headers['x-s-common'] = xs_common
     headers['x-b3-traceid'] = x_b3_traceid
+    if referer:
+        headers['referer'] = referer
     if data:
         data = json.dumps(data, separators=(',', ':'), ensure_ascii=False)
     return headers, data
 
-def generate_request_params(cookies_str, api, data='', method='POST'):
+def generate_request_params(cookies_str, api, data='', method='POST', referer=None):
     cookies = trans_cookies(cookies_str)
     a1 = cookies['a1']
-    headers, data = generate_headers(a1, api, data, method)
+    headers, data = generate_headers(a1, api, data, method, referer)
     return headers, cookies, data
 
 def splice_str(api, params):


### PR DESCRIPTION
## Summary

- **New pipeline** `spider_keyword_to_users()`: keyword search (time-sorted, image-only) → fetch comments → filter by region/time → pull user profiles → demographic filters → LLM marketing-account filter → LLM dating-tendency analysis → save to CSV
- **Anti-crawl hardening**: per-request Referer headers on comment and user-info endpoints, random UA rotation, request rate limiting (5–15 s + 60–120 s cooldown every 10 requests), session keepalive ping every 10 min, zero-comment note skip, randomised note-fetch order
- **Session safety**: cookie health probe at pipeline start; early `SessionExpiredError` raised on any login-expiry response; clear error message shown to user
- **LLM (local Ollama qwen2.5:7b)**: `is_marketing_account()` filters promotional accounts before `analyze_dating_tendency()` classifies remaining users
- **New files**: `xhs_utils/llm_util.py`, `run.sh` (PYTHONPATH launcher), `test_phase1.py` (smoke test)
- **`.gitignore`**: added `.env` and `datas/` to prevent credential and output leaks

## Test plan

- [ ] Run `bash run.sh` with a fresh cookie; confirm `[Pipeline] Cookie 有效` log line
- [ ] Confirm zero-comment notes are logged as skipped
- [ ] Let pipeline run past 10 requests; confirm cooldown log fires
- [ ] Expire cookie manually (delete from `.env`); confirm `SessionExpiredError` message is shown and pipeline stops cleanly
- [ ] Confirm `datas/excel_datas/` is not tracked by git after this change
- [ ] Check output CSV for `交友倾向` and `判断理由` columns populated by LLM
- [ ] Confirm营销号 are excluded from the user CSV